### PR TITLE
Migrate to VM v1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-context"
-version = "1.3.3"
+version = "1.4.1"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]
@@ -20,12 +20,12 @@ regex = "1.9"
 once_cell = "1.17"
 num = "0.4"
 hex = "0.4"
-sha2 = "0.10"
+sha2 = "0.10.6"
 sha3 = "0.10"
 md5 = "0.7"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs", branch = "v1.3.2" }
-zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.3.2" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs", branch = "v1.4.1" }
+zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]


### PR DESCRIPTION
# What ❔

Updates the assembler to v1.4.1.

## Why ❔

The version v1.4.1 must be tested.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
