### PR TITLE
Add noinline+optnone attributes in M0

### DIFF
--- a/src/eravm/context/function/llvm_runtime.rs
+++ b/src/eravm/context/function/llvm_runtime.rs
@@ -446,7 +446,7 @@ impl<'ctx> LLVMRuntime<'ctx> {
             Some(inkwell::module::Linkage::External),
         );
         Function::set_default_attributes(llvm, mstore8, optimizer);
-        Function::set_function_attributes(
+        Function::set_attributes(
             llvm,
             mstore8,
             vec![
@@ -454,6 +454,7 @@ impl<'ctx> LLVMRuntime<'ctx> {
                 Attribute::NoUnwind,
                 Attribute::WillReturn,
             ],
+            false,
         );
 
         let sha3 = Self::declare(
@@ -479,10 +480,11 @@ impl<'ctx> LLVMRuntime<'ctx> {
             Some(inkwell::module::Linkage::External),
         );
         Function::set_default_attributes(llvm, sha3, optimizer);
-        Function::set_function_attributes(
+        Function::set_attributes(
             llvm,
             sha3,
             vec![Attribute::ArgMemOnly, Attribute::ReadOnly],
+            false,
         );
 
         let system_request = Self::declare(
@@ -511,10 +513,11 @@ impl<'ctx> LLVMRuntime<'ctx> {
             Some(inkwell::module::Linkage::External),
         );
         Function::set_default_attributes(llvm, system_request, optimizer);
-        Function::set_function_attributes(
+        Function::set_attributes(
             llvm,
             system_request,
             vec![Attribute::ArgMemOnly, Attribute::ReadOnly],
+            false,
         );
 
         let external_call_arguments: Vec<inkwell::types::BasicMetadataTypeEnum> = vec![

--- a/src/eravm/context/function/mod.rs
+++ b/src/eravm/context/function/mod.rs
@@ -145,29 +145,41 @@ impl<'ctx> Function<'ctx> {
         force: bool,
     ) {
         for attribute_kind in attributes.into_iter() {
-            let is_optimize_none_set = declaration
-                .value
-                .get_enum_attribute(
+            match attribute_kind {
+                attribute_kind @ Attribute::AlwaysInline if force => {
+                    let is_optimize_none_set = declaration
+                        .value
+                        .get_enum_attribute(
+                            inkwell::attributes::AttributeLoc::Function,
+                            Attribute::OptimizeNone as u32,
+                        )
+                        .is_some();
+                    if !is_optimize_none_set {
+                        declaration.value.remove_enum_attribute(
+                            inkwell::attributes::AttributeLoc::Function,
+                            Attribute::NoInline as u32,
+                        );
+                        declaration.value.add_attribute(
+                            inkwell::attributes::AttributeLoc::Function,
+                            llvm.create_enum_attribute(attribute_kind as u32, 0),
+                        );
+                    }
+                }
+                attribute_kind @ Attribute::NoInline if force => {
+                    declaration.value.remove_enum_attribute(
+                        inkwell::attributes::AttributeLoc::Function,
+                        Attribute::AlwaysInline as u32,
+                    );
+                    declaration.value.add_attribute(
+                        inkwell::attributes::AttributeLoc::Function,
+                        llvm.create_enum_attribute(attribute_kind as u32, 0),
+                    );
+                }
+                attribute_kind => declaration.value.add_attribute(
                     inkwell::attributes::AttributeLoc::Function,
-                    Attribute::OptimizeNone as u32,
-                )
-                .is_some();
-            if !is_optimize_none_set && attribute_kind == Attribute::AlwaysInline && force {
-                declaration.value.remove_enum_attribute(
-                    inkwell::attributes::AttributeLoc::Function,
-                    Attribute::NoInline as u32,
-                );
-                declaration.value.add_attribute(
-                    inkwell::attributes::AttributeLoc::Function,
-                    llvm.create_enum_attribute(Attribute::AlwaysInline as u32, 0),
-                );
-                continue;
+                    llvm.create_enum_attribute(attribute_kind as u32, 0),
+                ),
             }
-
-            declaration.value.add_attribute(
-                inkwell::attributes::AttributeLoc::Function,
-                llvm.create_enum_attribute(attribute_kind as u32, 0),
-            );
         }
     }
 

--- a/src/eravm/context/function/mod.rs
+++ b/src/eravm/context/function/mod.rs
@@ -158,6 +158,17 @@ impl<'ctx> Function<'ctx> {
         declaration: Declaration<'ctx>,
         optimizer: &Optimizer,
     ) {
+        if optimizer.settings().level_middle_end == inkwell::OptimizationLevel::None {
+            declaration.value.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                llvm.create_enum_attribute(Attribute::OptimizeNone as u32, 0),
+            );
+            declaration.value.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                llvm.create_enum_attribute(Attribute::NoInline as u32, 0),
+            );
+        }
+
         if optimizer.settings().level_middle_end_size == SizeLevel::Z {
             declaration.value.add_attribute(
                 inkwell::attributes::AttributeLoc::Function,

--- a/src/eravm/context/function/mod.rs
+++ b/src/eravm/context/function/mod.rs
@@ -145,11 +145,23 @@ impl<'ctx> Function<'ctx> {
         force: bool,
     ) {
         for attribute_kind in attributes.into_iter() {
-            if attribute_kind == Attribute::AlwaysInline && force {
+            let is_optimize_none_set = declaration
+                .value
+                .get_enum_attribute(
+                    inkwell::attributes::AttributeLoc::Function,
+                    Attribute::OptimizeNone as u32,
+                )
+                .is_some();
+            if !is_optimize_none_set && attribute_kind == Attribute::AlwaysInline && force {
                 declaration.value.remove_enum_attribute(
                     inkwell::attributes::AttributeLoc::Function,
                     Attribute::NoInline as u32,
                 );
+                declaration.value.add_attribute(
+                    inkwell::attributes::AttributeLoc::Function,
+                    llvm.create_enum_attribute(Attribute::AlwaysInline as u32, 0),
+                );
+                continue;
             }
 
             declaration.value.add_attribute(


### PR DESCRIPTION
# What ❔

Adds `optnone` and `noinline` attributes to all functions if middle-end optimizations are disabled.

## Why ❔

It should disable some RAM-demanding LLVM passes which cause OOM on large unoptimized codebases.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
