### PR TITLE
Add the EVM version enum

### DIFF
--- a/src/evm_version.rs
+++ b/src/evm_version.rs
@@ -1,0 +1,107 @@
+//!
+//! The EVM version.
+//!
+
+use serde::Deserialize;
+use serde::Serialize;
+
+///
+/// The EVM version.
+///
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum EVMVersion {
+    /// The corresponding EVM version.
+    #[serde(rename = "homestead")]
+    Homestead,
+    /// The corresponding EVM version.
+    #[serde(rename = "tangerineWhistle")]
+    TangerineWhistle,
+    /// The corresponding EVM version.
+    #[serde(rename = "spuriousDragon")]
+    SpuriousDragon,
+    /// The corresponding EVM version.
+    #[serde(rename = "byzantium")]
+    Byzantium,
+    /// The corresponding EVM version.
+    #[serde(rename = "constantinople")]
+    Constantinople,
+    /// The corresponding EVM version.
+    #[serde(rename = "petersburg")]
+    Petersburg,
+    /// The corresponding EVM version.
+    #[serde(rename = "istanbul")]
+    Istanbul,
+    /// The corresponding EVM version.
+    #[serde(rename = "berlin")]
+    Berlin,
+    /// The corresponding EVM version.
+    #[serde(rename = "london")]
+    London,
+    /// The corresponding EVM version.
+    #[serde(rename = "paris")]
+    Paris,
+    /// The corresponding EVM version.
+    #[serde(rename = "shanghai")]
+    Shanghai,
+    /// The corresponding EVM version.
+    #[serde(rename = "cancun")]
+    Cancun,
+    /// The corresponding EVM version.
+    #[serde(rename = "atlantis")]
+    Atlantis,
+    /// The corresponding EVM version.
+    #[serde(rename = "agharta")]
+    Agharta,
+}
+
+impl Default for EVMVersion {
+    fn default() -> Self {
+        Self::Shanghai
+    }
+}
+
+impl TryFrom<&str> for EVMVersion {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(match value {
+            "homestead" => Self::Homestead,
+            "tangerineWhistle" => Self::TangerineWhistle,
+            "spuriousDragon" => Self::SpuriousDragon,
+            "byzantium" => Self::Byzantium,
+            "constantinople" => Self::Constantinople,
+            "petersburg" => Self::Petersburg,
+            "istanbul" => Self::Istanbul,
+            "berlin" => Self::Berlin,
+            "london" => Self::London,
+            "paris" => Self::Paris,
+            "shanghai" => Self::Shanghai,
+            "cancun" => Self::Cancun,
+            "atlantis" => Self::Atlantis,
+            "agharta" => Self::Agharta,
+            _ => anyhow::bail!("Invalid EVM version: {}", value),
+        })
+    }
+}
+
+impl std::fmt::Display for EVMVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Homestead => write!(f, "homestead"),
+            Self::TangerineWhistle => write!(f, "tangerineWhistle"),
+            Self::SpuriousDragon => write!(f, "spuriousDragon"),
+            Self::Byzantium => write!(f, "byzantium"),
+            Self::Constantinople => write!(f, "constantinople"),
+            Self::Petersburg => write!(f, "petersburg"),
+            Self::Istanbul => write!(f, "istanbul"),
+            Self::Berlin => write!(f, "berlin"),
+            Self::London => write!(f, "london"),
+            Self::Paris => write!(f, "paris"),
+            Self::Shanghai => write!(f, "shanghai"),
+            Self::Cancun => write!(f, "cancun"),
+            Self::Atlantis => write!(f, "atlantis"),
+            Self::Agharta => write!(f, "agharta"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod debug_config;
 pub(crate) mod eravm;
+pub(crate) mod evm_version;
 pub(crate) mod optimizer;
 pub(crate) mod target_machine;
 
@@ -66,6 +67,7 @@ pub use self::eravm::Dependency as EraVMDependency;
 pub use self::eravm::DummyDependency as EraVMDummyDependency;
 pub use self::eravm::DummyLLVMWritable as EraVMDummyLLVMWritable;
 pub use self::eravm::WriteLLVM as EraVMWriteLLVM;
+pub use self::evm_version::EVMVersion;
 pub use self::optimizer::settings::size_level::SizeLevel as OptimizerSettingsSizeLevel;
 pub use self::optimizer::settings::Settings as OptimizerSettings;
 pub use self::optimizer::Optimizer;


### PR DESCRIPTION
# What ❔

Adds an EVM version enum for usage throughout all compiler projects.

## Why ❔

It is better to have one enum for all.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
