### PR TITLE
Add a flag to disable SC calls memoization

### DIFF
--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -225,7 +225,7 @@ where
             Ok(build) => build,
             Err(_error)
                 if self.optimizer.settings() != &OptimizerSettings::size()
-                    && self.optimizer.settings().has_fallback_to_size() =>
+                    && self.optimizer.settings().is_fallback_to_size_enabled() =>
             {
                 self.optimizer = Optimizer::new(OptimizerSettings::size());
                 self.module = module_clone;

--- a/src/optimizer/settings/mod.rs
+++ b/src/optimizer/settings/mod.rs
@@ -24,7 +24,9 @@ pub struct Settings {
     pub level_back_end: inkwell::OptimizationLevel,
 
     /// Fallback to optimizing for size if the bytecode is too large.
-    pub has_fallback_to_size_enabled: bool,
+    pub is_fallback_to_size_enabled: bool,
+    /// Whether the system request memoization is disabled.
+    pub is_system_request_memoization_disabled: bool,
 
     /// Whether the LLVM `verify each` option is enabled.
     pub is_verify_each_enabled: bool,
@@ -46,7 +48,8 @@ impl Settings {
             level_middle_end_size,
             level_back_end,
 
-            has_fallback_to_size_enabled: false,
+            is_fallback_to_size_enabled: false,
+            is_system_request_memoization_disabled: false,
 
             is_verify_each_enabled: false,
             is_debug_logging_enabled: false,
@@ -69,7 +72,8 @@ impl Settings {
             level_middle_end_size,
             level_back_end,
 
-            has_fallback_to_size_enabled: false,
+            is_fallback_to_size_enabled: false,
+            is_system_request_memoization_disabled: false,
 
             is_verify_each_enabled,
             is_debug_logging_enabled,
@@ -223,15 +227,29 @@ impl Settings {
     ///
     /// Sets the fallback to optimizing for size if the bytecode is too large.
     ///
-    pub fn set_fallback_to_size(&mut self) {
-        self.has_fallback_to_size_enabled = true;
+    pub fn enable_fallback_to_size(&mut self) {
+        self.is_fallback_to_size_enabled = true;
     }
 
     ///
-    /// Gets the fallback to optimizing for size if the bytecode is too large.
+    /// Disables the system request memoization.
     ///
-    pub fn has_fallback_to_size(&self) -> bool {
-        self.has_fallback_to_size_enabled
+    pub fn disable_system_request_memoization(&mut self) {
+        self.is_system_request_memoization_disabled = true;
+    }
+
+    ///
+    /// Whether the fallback to optimizing for size is enabled.
+    ///
+    pub fn is_fallback_to_size_enabled(&self) -> bool {
+        self.is_fallback_to_size_enabled
+    }
+
+    ///
+    /// Whether the system request memoization is disabled.
+    ///
+    pub fn is_system_request_memoization_disabled(&self) -> bool {
+        self.is_system_request_memoization_disabled
     }
 }
 

--- a/src/target_machine/mod.rs
+++ b/src/target_machine/mod.rs
@@ -38,13 +38,13 @@ impl TargetMachine {
     /// A separate instance for every optimization level is created.
     ///
     pub fn new(target: Target, optimizer_settings: &OptimizerSettings) -> anyhow::Result<Self> {
-        // if optimizer_settings.is_system_request_memoization_disabled() {
-        inkwell::support::parse_command_line_options(
-            2,
-            &[target.name(), "-eravm-disable-sha3-sreq-cse"],
-            "Disables system request memoization",
-        );
-        // }
+        if optimizer_settings.is_system_request_memoization_disabled() {
+            inkwell::support::parse_command_line_options(
+                2,
+                &[target.name(), "-eravm-disable-sha3-sreq-cse"],
+                "Disables system request memoization",
+            );
+        }
 
         let target_machine = inkwell::targets::Target::from_name(target.name())
             .ok_or_else(|| anyhow::anyhow!("LLVM target machine `{}` not found", target.name()))?

--- a/src/target_machine/mod.rs
+++ b/src/target_machine/mod.rs
@@ -38,13 +38,13 @@ impl TargetMachine {
     /// A separate instance for every optimization level is created.
     ///
     pub fn new(target: Target, optimizer_settings: &OptimizerSettings) -> anyhow::Result<Self> {
-        if optimizer_settings.is_system_request_memoization_disabled() {
-            inkwell::support::parse_command_line_options(
-                2,
-                &[target.name(), "-eravm-disable-sha3-sreq-cse"],
-                "Disables system request memoization",
-            );
-        }
+        // if optimizer_settings.is_system_request_memoization_disabled() {
+        inkwell::support::parse_command_line_options(
+            2,
+            &[target.name(), "-eravm-disable-sha3-sreq-cse"],
+            "Disables system request memoization",
+        );
+        // }
 
         let target_machine = inkwell::targets::Target::from_name(target.name())
             .ok_or_else(|| anyhow::anyhow!("LLVM target machine `{}` not found", target.name()))?

--- a/src/target_machine/mod.rs
+++ b/src/target_machine/mod.rs
@@ -38,6 +38,14 @@ impl TargetMachine {
     /// A separate instance for every optimization level is created.
     ///
     pub fn new(target: Target, optimizer_settings: &OptimizerSettings) -> anyhow::Result<Self> {
+        if optimizer_settings.is_system_request_memoization_disabled() {
+            inkwell::support::parse_command_line_options(
+                2,
+                &[target.name(), "-eravm-disable-sha3-sreq-cse"],
+                "Disables system request memoization",
+            );
+        }
+
         let target_machine = inkwell::targets::Target::from_name(target.name())
             .ok_or_else(|| anyhow::anyhow!("LLVM target machine `{}` not found", target.name()))?
             .create_target_machine(


### PR DESCRIPTION
# What ❔

Adds an optimizer flag to disable SC calls memoization.

## Why ❔

Some applications require such optimizations to be disabled, e.g. for a bootloader upgrade.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
