### PR TITLE
Add the deploy_call for both heaps

### DIFF
--- a/src/eravm/context/function/runtime/deployer_call.rs
+++ b/src/eravm/context/function/runtime/deployer_call.rs
@@ -28,9 +28,6 @@ pub struct DeployerCall {
 }
 
 impl DeployerCall {
-    /// The default function name.
-    pub const FUNCTION_NAME: &'static str = "__deployer_call";
-
     /// The value argument index.
     pub const ARGUMENT_INDEX_VALUE: usize = 0;
 
@@ -46,11 +43,25 @@ impl DeployerCall {
     /// The salt argument index.
     pub const ARGUMENT_INDEX_SALT: usize = 4;
 
+    /// The heap function name.
+    const FUNCTION_NAME: &'static str = "__deployer_call";
+
     ///
     /// A shortcut constructor.
     ///
     pub fn new(address_space: AddressSpace) -> Self {
         Self { address_space }
+    }
+
+    ///
+    /// Returns the function name based on its address space.
+    ///
+    pub fn name(address_space: AddressSpace) -> String {
+        match address_space {
+            AddressSpace::HeapAuxiliary => format!("{}_aux", Self::FUNCTION_NAME),
+            AddressSpace::Heap => Self::FUNCTION_NAME.to_owned(),
+            _ => panic!("DeployerCall can only use Heap or HeapAuxiliary address spaces"),
+        }
     }
 }
 
@@ -71,7 +82,7 @@ where
             false,
         );
         let function = context.add_function(
-            Self::FUNCTION_NAME,
+            Self::name(self.address_space).as_str(),
             function_type,
             1,
             Some(inkwell::module::Linkage::Private),
@@ -86,7 +97,7 @@ where
     }
 
     fn into_llvm(self, context: &mut Context<D>) -> anyhow::Result<()> {
-        context.set_current_function(Self::FUNCTION_NAME)?;
+        context.set_current_function(Self::name(self.address_space).as_str())?;
 
         let value = context
             .current_function()

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -5,6 +5,7 @@
 use inkwell::values::BasicValue;
 use num::Zero;
 
+use crate::eravm::context::address_space::AddressSpace;
 use crate::eravm::context::argument::Argument;
 use crate::eravm::context::code_type::CodeType;
 use crate::eravm::context::function::runtime::Runtime;
@@ -18,6 +19,7 @@ use crate::eravm::Dependency;
 ///
 pub fn create<'ctx, D>(
     context: &mut Context<'ctx, D>,
+    address_space: AddressSpace,
     value: inkwell::values::IntValue<'ctx>,
     input_offset: inkwell::values::IntValue<'ctx>,
     input_length: inkwell::values::IntValue<'ctx>,
@@ -31,7 +33,7 @@ where
 
     let salt = context.field_const(0);
 
-    let function = Runtime::deployer_call(context);
+    let function = Runtime::deployer_call(context, address_space);
     let result = context
         .build_call(
             function,
@@ -56,6 +58,7 @@ where
 ///
 pub fn create2<'ctx, D>(
     context: &mut Context<'ctx, D>,
+    address_space: AddressSpace,
     value: inkwell::values::IntValue<'ctx>,
     input_offset: inkwell::values::IntValue<'ctx>,
     input_length: inkwell::values::IntValue<'ctx>,
@@ -70,7 +73,7 @@ where
 
     let salt = salt.unwrap_or_else(|| context.field_const(0));
 
-    let function = Runtime::deployer_call(context);
+    let function = Runtime::deployer_call(context, address_space);
     let result = context
         .build_call(
             function,


### PR DESCRIPTION
# What ❔

Now it is possible to use `deployer_call` using both heap and auxiliary heap from the same contract.

## Why ❔

Vyper contracts can be using `create_minimal_proxy_to` with the auxiliary heap, and `create_from_blueprint` with the ordinary heap.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
