### PR TITLE
Rename forwarder to minimal proxy

### DIFF
--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -461,7 +461,7 @@ where
     ///
     pub fn compile_dependency(&mut self, name: &str) -> anyhow::Result<String> {
         if let Some(vyper_data) = self.vyper_data.as_mut() {
-            vyper_data.set_is_forwarder_used();
+            vyper_data.set_is_minimal_proxy_used();
         }
         self.dependency_manager
             .to_owned()

--- a/src/eravm/context/vyper_data.rs
+++ b/src/eravm/context/vyper_data.rs
@@ -12,18 +12,18 @@ pub struct VyperData {
     /// The immutables size tracker. Stores the size in bytes.
     /// Does not take into account the size of the indexes.
     immutables_size: usize,
-    /// Whether the contract forwarder has been used.
-    is_forwarder_used: bool,
+    /// Whether the contract minimal proxy has been used.
+    is_minimal_proxy_used: bool,
 }
 
 impl VyperData {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(immutables_size: usize, is_forwarder_used: bool) -> Self {
+    pub fn new(immutables_size: usize, is_minimal_proxy_used: bool) -> Self {
         Self {
             immutables_size,
-            is_forwarder_used,
+            is_minimal_proxy_used,
         }
     }
 
@@ -35,16 +35,16 @@ impl VyperData {
     }
 
     ///
-    /// Sets the forwarder usage flag.
+    /// Sets the minimal proxy usage flag.
     ///
-    pub fn set_is_forwarder_used(&mut self) {
-        self.is_forwarder_used = true;
+    pub fn set_is_minimal_proxy_used(&mut self) {
+        self.is_minimal_proxy_used = true;
     }
 
     ///
-    /// Returns the forwarder usage flag.
+    /// Returns the minimal proxy usage flag.
     ///
-    pub fn is_forwarder_used(&self) -> bool {
-        self.is_forwarder_used
+    pub fn is_minimal_proxy_used(&self) -> bool {
+        self.is_minimal_proxy_used
     }
 }


### PR DESCRIPTION
# What ❔

Renames the Vyper forwarder to minimal proxy.

## Why ❔

The name was changed by Vyper in v0.3.4.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
