### PR TITLE
Support swapping 16 active pointers

### DIFF
--- a/src/eravm/const.rs
+++ b/src/eravm/const.rs
@@ -29,14 +29,20 @@ pub static GLOBAL_CALL_FLAGS: &str = "call_flags";
 /// The extra ABI data global variable name.
 pub static GLOBAL_EXTRA_ABI_DATA: &str = "extra_abi_data";
 
+/// The active pointer prefix.
+pub static GLOBAL_ACTIVE_POINTER_PREFIX: &str = "ptr_active";
+
 /// The active pointer global variable name.
-pub static GLOBAL_ACTIVE_POINTER: &str = "ptr_active";
+pub static GLOBAL_ACTIVE_POINTER: &str = "ptr_active_0";
 
 /// The constant array global variable name prefix.
 pub static GLOBAL_CONST_ARRAY_PREFIX: &str = "const_array_";
 
 /// The global verbatim getter identifier prefix.
 pub static GLOBAL_VERBATIM_GETTER_PREFIX: &str = "get_global::";
+
+/// The number of available active pointers.
+pub const AVAILABLE_ACTIVE_POINTERS_NUMBER: usize = 16;
 
 /// The external call data offset in the auxiliary heap.
 pub const HEAP_AUX_OFFSET_EXTERNAL_CALL: u64 = 0;

--- a/src/eravm/const.rs
+++ b/src/eravm/const.rs
@@ -29,11 +29,8 @@ pub static GLOBAL_CALL_FLAGS: &str = "call_flags";
 /// The extra ABI data global variable name.
 pub static GLOBAL_EXTRA_ABI_DATA: &str = "extra_abi_data";
 
-/// The active pointer prefix.
-pub static GLOBAL_ACTIVE_POINTER_PREFIX: &str = "ptr_active";
-
-/// The active pointer global variable name.
-pub static GLOBAL_ACTIVE_POINTER: &str = "ptr_active_0";
+/// The active pointer array global variable name.
+pub static GLOBAL_ACTIVE_POINTER_ARRAY: &str = "ptr_active";
 
 /// The constant array global variable name prefix.
 pub static GLOBAL_CONST_ARRAY_PREFIX: &str = "const_array_";

--- a/src/eravm/context/function/runtime/entry.rs
+++ b/src/eravm/context/function/runtime/entry.rs
@@ -156,7 +156,10 @@ where
             calldata_end_pointer,
             crate::eravm::GLOBAL_RETURN_DATA_POINTER,
         );
-        context.write_abi_pointer(calldata_end_pointer, crate::eravm::GLOBAL_ACTIVE_POINTER);
+        for index in 0..crate::eravm_const::AVAILABLE_ACTIVE_POINTERS_NUMBER {
+            let name = format!("{}_{index}", crate::eravm::GLOBAL_ACTIVE_POINTER_PREFIX);
+            context.write_abi_pointer(calldata_end_pointer, name.as_str());
+        }
 
         let call_flags = context
             .current_function()

--- a/src/eravm/context/function/runtime/entry.rs
+++ b/src/eravm/context/function/runtime/entry.rs
@@ -78,6 +78,20 @@ impl Entry {
             extra_abi_data_type.const_zero(),
         );
 
+        let generic_byte_pointer_type = context.byte_type().ptr_type(AddressSpace::Generic.into());
+        context.set_global(
+            crate::eravm::GLOBAL_ACTIVE_POINTER_ARRAY,
+            generic_byte_pointer_type
+                .array_type(crate::eravm_const::AVAILABLE_ACTIVE_POINTERS_NUMBER as u32),
+            AddressSpace::Stack,
+            context
+                .array_type(
+                    generic_byte_pointer_type,
+                    crate::eravm_const::AVAILABLE_ACTIVE_POINTERS_NUMBER,
+                )
+                .const_zero(),
+        );
+
         Ok(())
     }
 }
@@ -157,8 +171,10 @@ where
             crate::eravm::GLOBAL_RETURN_DATA_POINTER,
         );
         for index in 0..crate::eravm_const::AVAILABLE_ACTIVE_POINTERS_NUMBER {
-            let name = format!("{}_{index}", crate::eravm::GLOBAL_ACTIVE_POINTER_PREFIX);
-            context.write_abi_pointer(calldata_end_pointer, name.as_str());
+            context.set_active_pointer(
+                context.field_const(index as u64),
+                calldata_end_pointer.value,
+            )?;
         }
 
         let call_flags = context

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -323,6 +323,51 @@ where
     }
 
     ///
+    /// Returns the active pointer at `index`.
+    ///
+    pub fn get_active_pointer(
+        &self,
+        index: inkwell::values::IntValue<'ctx>,
+    ) -> anyhow::Result<inkwell::values::PointerValue<'ctx>> {
+        let active_pointer_array_global = self
+            .globals
+            .get(crate::eravm_const::GLOBAL_ACTIVE_POINTER_ARRAY)
+            .expect("Always exists")
+            .to_owned();
+        let active_pointer_pointer = self.build_gep(
+            active_pointer_array_global.into(),
+            &[self.field_const(0), index],
+            self.byte_type().ptr_type(AddressSpace::Generic.into()),
+            "active_pointer_pointer",
+        );
+        let active_pointer = self.build_load(active_pointer_pointer, "active_pointer");
+        Ok(active_pointer.into_pointer_value())
+    }
+
+    ///
+    /// Sets the active pointer at `index`.
+    ///
+    pub fn set_active_pointer(
+        &self,
+        index: inkwell::values::IntValue<'ctx>,
+        pointer: inkwell::values::PointerValue<'ctx>,
+    ) -> anyhow::Result<()> {
+        let active_pointer_array_global = self
+            .globals
+            .get(crate::eravm_const::GLOBAL_ACTIVE_POINTER_ARRAY)
+            .expect("Always exists")
+            .to_owned();
+        let active_pointer_pointer = self.build_gep(
+            active_pointer_array_global.into(),
+            &[self.field_const(0), index],
+            self.byte_type().ptr_type(AddressSpace::Generic.into()),
+            "active_pointer_pointer",
+        );
+        self.build_store(active_pointer_pointer, pointer);
+        Ok(())
+    }
+
+    ///
     /// Returns the LLVM intrinsics collection reference.
     ///
     pub fn intrinsics(&self) -> &Intrinsics<'ctx> {

--- a/src/eravm/evm/call.rs
+++ b/src/eravm/evm/call.rs
@@ -118,7 +118,7 @@ where
             Some(era_compiler_common::ERAVM_ADDRESS_MIMIC_CALL_BYREF) => {
                 let address = gas;
                 let mimic = input_length;
-                let abi_data = context.get_global_value(crate::eravm::GLOBAL_ACTIVE_POINTER)?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 return crate::eravm::extensions::call::mimic(
                     context,
@@ -132,7 +132,7 @@ where
             Some(era_compiler_common::ERAVM_ADDRESS_SYSTEM_MIMIC_CALL_BYREF) => {
                 let address = gas;
                 let mimic = input_length;
-                let abi_data = context.get_global_value(crate::eravm::GLOBAL_ACTIVE_POINTER)?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
                 let extra_value_1 = output_offset;
                 let extra_value_2 = output_length;
 
@@ -141,7 +141,7 @@ where
                     context.llvm_runtime().mimic_call_byref,
                     address,
                     mimic,
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     vec![extra_value_1, extra_value_2],
                 );
             }
@@ -160,13 +160,13 @@ where
             }
             Some(era_compiler_common::ERAVM_ADDRESS_RAW_FAR_CALL_BYREF) => {
                 let address = gas;
-                let abi_data = context.get_global_value(crate::eravm::GLOBAL_ACTIVE_POINTER)?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
 
                 return crate::eravm::extensions::call::raw_far(
                     context,
                     context.llvm_runtime().modify(function, true)?,
                     address,
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     output_offset,
                     output_length,
                 );
@@ -191,7 +191,7 @@ where
             }
             Some(era_compiler_common::ERAVM_ADDRESS_SYSTEM_CALL_BYREF) => {
                 let address = gas;
-                let abi_data = context.get_global_value(crate::eravm::GLOBAL_ACTIVE_POINTER)?;
+                let abi_data = context.get_active_pointer(context.field_const(0))?;
                 let extra_value_1 = value.expect("Always exists");
                 let extra_value_2 = input_offset;
                 let extra_value_3 = output_offset;
@@ -201,7 +201,7 @@ where
                     context,
                     context.llvm_runtime().modify(function, true)?,
                     address,
-                    abi_data,
+                    abi_data.as_basic_value_enum(),
                     context.field_const(0),
                     context.field_const(0),
                     vec![extra_value_1, extra_value_2, extra_value_3, extra_value_4],
@@ -418,6 +418,18 @@ where
                     source_offset,
                     size,
                 );
+            }
+            Some(era_compiler_common::ERAVM_ADDRESS_ACTIVE_PTR_SWAP) => {
+                crate::eravm::extensions::call::validate_call_type(
+                    context.llvm_runtime().static_call,
+                    function,
+                    "active_ptr_swap",
+                )?;
+
+                let index_1 = gas;
+                let index_2 = input_offset;
+
+                return crate::eravm::extensions::abi::active_ptr_swap(context, index_1, index_2);
             }
             Some(era_compiler_common::ERAVM_ADDRESS_CONST_ARRAY_DECLARE) => {
                 crate::eravm::extensions::call::validate_call_type(


### PR DESCRIPTION
# What ❔

Adds a simulation to swap active pointers.

## Why ❔

We are allowing 16 saved pointers now, where 0th will be the active one.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
