### PR TITLE
Add the jump table density threshold optimizer parameter

### DIFF
--- a/src/optimizer/settings/mod.rs
+++ b/src/optimizer/settings/mod.rs
@@ -27,6 +27,8 @@ pub struct Settings {
     pub is_fallback_to_size_enabled: bool,
     /// Whether the system request memoization is disabled.
     pub is_system_request_memoization_disabled: bool,
+    /// The jump table density threshold.
+    pub jump_table_density_threshold: Option<u32>,
 
     /// Whether the LLVM `verify each` option is enabled.
     pub is_verify_each_enabled: bool,
@@ -50,6 +52,7 @@ impl Settings {
 
             is_fallback_to_size_enabled: false,
             is_system_request_memoization_disabled: false,
+            jump_table_density_threshold: None,
 
             is_verify_each_enabled: false,
             is_debug_logging_enabled: false,
@@ -74,6 +77,7 @@ impl Settings {
 
             is_fallback_to_size_enabled: false,
             is_system_request_memoization_disabled: false,
+            jump_table_density_threshold: None,
 
             is_verify_each_enabled,
             is_debug_logging_enabled,
@@ -239,6 +243,13 @@ impl Settings {
     }
 
     ///
+    /// Sets the jump table density threshold.
+    ///
+    pub fn set_jump_table_density_threshold(&mut self, threshold: u32) {
+        self.jump_table_density_threshold = Some(threshold);
+    }
+
+    ///
     /// Whether the fallback to optimizing for size is enabled.
     ///
     pub fn is_fallback_to_size_enabled(&self) -> bool {
@@ -250,6 +261,13 @@ impl Settings {
     ///
     pub fn is_system_request_memoization_disabled(&self) -> bool {
         self.is_system_request_memoization_disabled
+    }
+
+    ///
+    /// Returns the jump table density threshold.
+    ///
+    pub fn jump_table_density_threshold(&self) -> Option<u32> {
+        self.jump_table_density_threshold
     }
 }
 

--- a/src/target_machine/mod.rs
+++ b/src/target_machine/mod.rs
@@ -44,7 +44,8 @@ impl TargetMachine {
             arguments.push("-eravm-disable-sha3-sreq-cse".to_owned());
         }
         if let Some(value) = optimizer_settings.jump_table_density_threshold() {
-            arguments.push(format!("-eravm-jump-table-density-threshold={}", value));
+            arguments.push("-eravm-jump-table-density-threshold".to_owned());
+            arguments.push(value.to_string());
         }
         if arguments.len() > 1 {
             let arguments: Vec<&str> = arguments.iter().map(|argument| argument.as_str()).collect();

--- a/src/target_machine/mod.rs
+++ b/src/target_machine/mod.rs
@@ -38,11 +38,20 @@ impl TargetMachine {
     /// A separate instance for every optimization level is created.
     ///
     pub fn new(target: Target, optimizer_settings: &OptimizerSettings) -> anyhow::Result<Self> {
+        let mut arguments = Vec::with_capacity(3);
+        arguments.push(target.name().to_owned());
         if optimizer_settings.is_system_request_memoization_disabled() {
+            arguments.push("-eravm-disable-sha3-sreq-cse".to_owned());
+        }
+        if let Some(value) = optimizer_settings.jump_table_density_threshold() {
+            arguments.push(format!("-eravm-jump-table-density-threshold={}", value));
+        }
+        if arguments.len() > 1 {
+            let arguments: Vec<&str> = arguments.iter().map(|argument| argument.as_str()).collect();
             inkwell::support::parse_command_line_options(
-                2,
-                &[target.name(), "-eravm-disable-sha3-sreq-cse"],
-                "Disables system request memoization",
+                arguments.len() as i32,
+                arguments.as_slice(),
+                "Optimizer parameters",
             );
         }
 


### PR DESCRIPTION
# What ❔

Adds the jump table density threshold optimizer parameter.

## Why ❔

This parameter is required for the jump table optimization, which is useful for the EVM interpreter on EraVM.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
