### PR TITLE
feature: support subdirectories for debug dumps

### DIFF
--- a/src/debug_config/mod.rs
+++ b/src/debug_config/mod.rs
@@ -33,7 +33,7 @@ impl DebugConfig {
     ///
     /// Rules to encode a string into a valid filename.
     ///
-    fn sanitize(string: &str) -> String {
+    fn sanitize_filename_fragment(string: &str) -> String {
         string
             .replace('/', "_")
             .replace(' ', "_")
@@ -45,7 +45,7 @@ impl DebugConfig {
     /// Create a subdirectory and return a copy of `DebugConfig` pointing there.
     ///
     pub fn create_subdirectory(&self, directory_name: &str) -> anyhow::Result<Self> {
-        let sanitized_name = &Self::sanitize(directory_name);
+        let sanitized_name = &Self::sanitize_filename_fragment(directory_name);
         let subdirectory_path = self.output_directory.join(sanitized_name);
         std::fs::create_dir_all(subdirectory_path.clone())?;
         Ok(Self {
@@ -187,7 +187,7 @@ impl DebugConfig {
         suffix: Option<&str>,
         ir_type: IRType,
     ) -> String {
-        let mut full_file_name = Self::sanitize(contract_path);
+        let mut full_file_name = Self::sanitize_filename_fragment(contract_path);
 
         if let Some(code_type) = code_type {
             full_file_name.push('.');

--- a/src/debug_config/mod.rs
+++ b/src/debug_config/mod.rs
@@ -31,7 +31,7 @@ impl DebugConfig {
     }
 
     ///
-    /// Rules to encode a string into a valid filename
+    /// Rules to encode a string into a valid filename.
     ///
     fn sanitize(string: &str) -> String {
         string
@@ -42,7 +42,7 @@ impl DebugConfig {
     }
 
     ///
-    /// Create a subdirectory and return a copy of `DebugConfig` pointing there
+    /// Create a subdirectory and return a copy of `DebugConfig` pointing there.
     ///
     pub fn create_subdirectory(&self, directory_name: &str) -> anyhow::Result<Self> {
         let sanitized_name = &Self::sanitize(directory_name);

--- a/src/debug_config/mod.rs
+++ b/src/debug_config/mod.rs
@@ -46,8 +46,8 @@ impl DebugConfig {
     ///
     pub fn create_subdirectory(&self, directory_name: &str) -> anyhow::Result<Self> {
         let sanitized_name = &Self::sanitize_filename_fragment(directory_name);
-        let subdirectory_path = self.output_directory.join(sanitized_name);
-        std::fs::create_dir_all(subdirectory_path.clone())?;
+        let subdirectory_path = self.output_directory.join(&sanitized_name);
+        std::fs::create_dir_all(&subdirectory_path)?;
         Ok(Self {
             output_directory: subdirectory_path,
         })

--- a/src/debug_config/mod.rs
+++ b/src/debug_config/mod.rs
@@ -31,23 +31,12 @@ impl DebugConfig {
     }
 
     ///
-    /// Rules to encode a string into a valid filename.
-    ///
-    fn sanitize_filename_fragment(string: &str) -> String {
-        string
-            .replace('/', "_")
-            .replace(' ', "_")
-            .replace('\t', "_")
-            .replace(':', ".")
-    }
-
-    ///
     /// Create a subdirectory and return a copy of `DebugConfig` pointing there.
     ///
     pub fn create_subdirectory(&self, directory_name: &str) -> anyhow::Result<Self> {
-        let sanitized_name = &Self::sanitize_filename_fragment(directory_name);
-        let subdirectory_path = self.output_directory.join(&sanitized_name);
-        std::fs::create_dir_all(&subdirectory_path)?;
+        let sanitized_name = Self::sanitize_filename_fragment(directory_name);
+        let subdirectory_path = self.output_directory.join(sanitized_name.as_str());
+        std::fs::create_dir_all(subdirectory_path.as_path())?;
         Ok(Self {
             output_directory: subdirectory_path,
         })
@@ -176,6 +165,13 @@ impl DebugConfig {
         std::fs::write(file_path, code)?;
 
         Ok(())
+    }
+
+    ///
+    /// Rules to encode a string into a valid filename.
+    ///
+    fn sanitize_filename_fragment(string: &str) -> String {
+        string.replace(['/', ' ', '\t'], "_")
     }
 
     ///

--- a/src/debug_config/mod.rs
+++ b/src/debug_config/mod.rs
@@ -31,6 +31,29 @@ impl DebugConfig {
     }
 
     ///
+    /// Rules to encode a string into a valid filename
+    ///
+    fn sanitize(string: &str) -> String {
+        string
+            .replace('/', "_")
+            .replace(' ', "_")
+            .replace('\t', "_")
+            .replace(':', ".")
+    }
+
+    ///
+    /// Create a subdirectory and return a copy of `DebugConfig` pointing there
+    ///
+    pub fn create_subdirectory(&self, directory_name: &str) -> anyhow::Result<Self> {
+        let sanitized_name = &Self::sanitize(directory_name);
+        let subdirectory_path = self.output_directory.join(sanitized_name);
+        std::fs::create_dir_all(subdirectory_path.clone())?;
+        Ok(Self {
+            output_directory: subdirectory_path,
+        })
+    }
+
+    ///
     /// Dumps the Yul IR.
     ///
     pub fn dump_yul(
@@ -164,7 +187,8 @@ impl DebugConfig {
         suffix: Option<&str>,
         ir_type: IRType,
     ) -> String {
-        let mut full_file_name = contract_path.replace('/', "_").replace(':', ".");
+        let mut full_file_name = Self::sanitize(contract_path);
+
         if let Some(code_type) = code_type {
             full_file_name.push('.');
             full_file_name.push_str(code_type.to_string().as_str());


### PR DESCRIPTION
# What ❔

Support creating subfolders in `debug/`.

## Why ❔

Compiler tester overrides IR dumps if they were produced by launching a test repeatedly with different modes.

This change should not break behavior expected from `era-compiler-llvm-context`.

Corresponding PR in compiler tester: https://github.com/matter-labs/era-compiler-tester/pull/11