### PR TITLE
fix: remove redundant dependency arguments

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,0 +1,49 @@
+//!
+//! The dependency trait.
+//!
+
+///
+/// Implemented by entities managing project dependencies.
+///
+pub trait Dependency {
+    ///
+    /// Gets the data of the specified dependency.
+    ///
+    fn get(&self, path: &str) -> anyhow::Result<String>;
+
+    ///
+    /// Resolves a full contract path.
+    ///
+    fn resolve_path(&self, identifier: &str) -> anyhow::Result<String>;
+
+    ///
+    /// Resolves a library address.
+    ///
+    fn resolve_library(&self, path: &str) -> anyhow::Result<String>;
+}
+
+///
+/// The dummy dependency entity.
+///
+#[derive(Debug, Default, Clone)]
+pub struct DummyDependency {}
+
+impl Dependency for DummyDependency {
+    fn get(&self, _path: &str) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+
+    ///
+    /// Resolves a full contract path.
+    ///
+    fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+
+    ///
+    /// Resolves a library address.
+    ///
+    fn resolve_library(&self, _path: &str) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+}

--- a/src/eravm/context/function/runtime/default_call.rs
+++ b/src/eravm/context/function/runtime/default_call.rs
@@ -75,7 +75,7 @@ impl DefaultCall {
     ///
     fn inner_function<'ctx, D>(&self, context: &Context<'ctx, D>) -> FunctionDeclaration<'ctx>
     where
-        D: Dependency + Clone,
+        D: Dependency,
     {
         match self.inner_name.as_str() {
             name if name == LLVMRuntime::FUNCTION_FARCALL => context.llvm_runtime().far_call,
@@ -90,7 +90,7 @@ impl DefaultCall {
 
 impl<D> WriteLLVM<D> for DefaultCall
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         let function_type = context.function_type(

--- a/src/eravm/context/function/runtime/deploy_code.rs
+++ b/src/eravm/context/function/runtime/deploy_code.rs
@@ -22,7 +22,7 @@ use crate::eravm::WriteLLVM;
 pub struct DeployCode<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     /// The deploy code AST representation.
     inner: B,
@@ -33,7 +33,7 @@ where
 impl<B, D> DeployCode<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     ///
     /// A shortcut constructor.
@@ -49,7 +49,7 @@ where
 impl<B, D> WriteLLVM<D> for DeployCode<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         let function_type =

--- a/src/eravm/context/function/runtime/deployer_call.rs
+++ b/src/eravm/context/function/runtime/deployer_call.rs
@@ -68,7 +68,7 @@ impl DeployerCall {
 
 impl<D> WriteLLVM<D> for DeployerCall
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         let function_type = context.function_type(

--- a/src/eravm/context/function/runtime/entry.rs
+++ b/src/eravm/context/function/runtime/entry.rs
@@ -39,7 +39,7 @@ impl Entry {
     ///
     pub fn initialize_globals<D>(context: &mut Context<D>) -> anyhow::Result<()>
     where
-        D: Dependency + Clone,
+        D: Dependency,
     {
         context.set_global(
             crate::eravm::GLOBAL_HEAP_MEMORY_POINTER,
@@ -99,7 +99,7 @@ impl Entry {
 
 impl<D> WriteLLVM<D> for Entry
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         let mut entry_arguments =

--- a/src/eravm/context/function/runtime/mod.rs
+++ b/src/eravm/context/function/runtime/mod.rs
@@ -42,7 +42,7 @@ impl Runtime {
         call_function: FunctionDeclaration<'ctx>,
     ) -> FunctionDeclaration<'ctx>
     where
-        D: Dependency + Clone,
+        D: Dependency,
     {
         context
             .get_function(DefaultCall::name(call_function).as_str())
@@ -59,7 +59,7 @@ impl Runtime {
         address_space: AddressSpace,
     ) -> FunctionDeclaration<'ctx>
     where
-        D: Dependency + Clone,
+        D: Dependency,
     {
         context
             .get_function(DeployerCall::name(address_space).as_str())
@@ -71,7 +71,7 @@ impl Runtime {
 
 impl<D> WriteLLVM<D> for Runtime
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         DefaultCall::new(context.llvm_runtime().far_call).declare(context)?;

--- a/src/eravm/context/function/runtime/runtime_code.rs
+++ b/src/eravm/context/function/runtime/runtime_code.rs
@@ -20,7 +20,7 @@ use crate::eravm::WriteLLVM;
 pub struct RuntimeCode<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     /// The runtime code AST representation.
     inner: B,
@@ -31,7 +31,7 @@ where
 impl<B, D> RuntimeCode<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     ///
     /// A shortcut constructor.
@@ -47,7 +47,7 @@ where
 impl<B, D> WriteLLVM<D> for RuntimeCode<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         let function_type =

--- a/src/eravm/context/global.rs
+++ b/src/eravm/context/global.rs
@@ -6,9 +6,9 @@ use inkwell::types::BasicType;
 use inkwell::values::BasicValue;
 
 use crate::context::IContext;
+use crate::dependency::Dependency;
 use crate::eravm::context::address_space::AddressSpace;
 use crate::eravm::context::Context;
-use crate::EraVMDependency;
 
 ///
 /// The LLVM global value.
@@ -33,7 +33,7 @@ impl<'ctx> Global<'ctx> {
         name: &str,
     ) -> anyhow::Result<Self>
     where
-        D: EraVMDependency + Clone,
+        D: Dependency + Clone,
         T: BasicType<'ctx>,
         V: BasicValue<'ctx>,
     {

--- a/src/eravm/context/global.rs
+++ b/src/eravm/context/global.rs
@@ -33,7 +33,7 @@ impl<'ctx> Global<'ctx> {
         name: &str,
     ) -> anyhow::Result<Self>
     where
-        D: Dependency + Clone,
+        D: Dependency,
         T: BasicType<'ctx>,
         V: BasicValue<'ctx>,
     {

--- a/src/eravm/context/tests.rs
+++ b/src/eravm/context/tests.rs
@@ -4,8 +4,8 @@
 
 use crate::context::attribute::Attribute;
 use crate::context::IContext;
+use crate::dependency::DummyDependency;
 use crate::eravm::context::Context;
-use crate::eravm::DummyDependency;
 use crate::optimizer::settings::Settings as OptimizerSettings;
 use crate::optimizer::Optimizer;
 
@@ -18,7 +18,7 @@ pub fn create_context(
     let module = llvm.create_module("test");
     let optimizer = Optimizer::new(optimizer_settings);
 
-    Context::<DummyDependency>::new(&llvm, module, vec![], optimizer, None, true, None)
+    Context::<DummyDependency>::new(&llvm, module, vec![], optimizer, None, None)
 }
 
 #[test]

--- a/src/eravm/evm/arithmetic.rs
+++ b/src/eravm/evm/arithmetic.rs
@@ -17,7 +17,7 @@ pub fn addition<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -34,7 +34,7 @@ pub fn subtraction<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -51,7 +51,7 @@ pub fn multiplication<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -68,7 +68,7 @@ pub fn division<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -91,7 +91,7 @@ pub fn remainder<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -118,7 +118,7 @@ pub fn division_signed<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -141,7 +141,7 @@ pub fn remainder_signed<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(

--- a/src/eravm/evm/bitwise.rs
+++ b/src/eravm/evm/bitwise.rs
@@ -17,7 +17,7 @@ pub fn or<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -34,7 +34,7 @@ pub fn xor<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -51,7 +51,7 @@ pub fn and<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -68,7 +68,7 @@ pub fn shift_left<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -91,7 +91,7 @@ pub fn shift_right<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -114,7 +114,7 @@ pub fn shift_right_arithmetic<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -137,7 +137,7 @@ pub fn byte<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(

--- a/src/eravm/evm/call.rs
+++ b/src/eravm/evm/call.rs
@@ -34,7 +34,7 @@ pub fn default<'ctx, D>(
     mut constants: Vec<Option<num::BigUint>>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     if context.are_eravm_extensions_enabled() {
         let simulation_address = constants
@@ -626,7 +626,7 @@ pub fn linker_symbol<'ctx, D>(
     mut arguments: [Value<'ctx>; 1],
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let path = arguments[0]
         .original
@@ -648,7 +648,7 @@ pub fn request<'ctx, D>(
     arguments: Vec<inkwell::values::IntValue<'ctx>>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let signature_hash = crate::eravm::utils::keccak256(signature.as_bytes());
     let signature_value = context.field_const_str_hex(signature_hash.as_str());
@@ -702,7 +702,7 @@ fn default_wrapped<'ctx, D>(
     output_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let value_zero_block = context.append_basic_block("contract_call_value_zero_block");
     let value_non_zero_block = context.append_basic_block("contract_call_value_non_zero_block");
@@ -778,7 +778,7 @@ fn identity<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination = Pointer::<AddressSpace>::new_with_offset(
         context,

--- a/src/eravm/evm/calldata.rs
+++ b/src/eravm/evm/calldata.rs
@@ -18,7 +18,7 @@ pub fn load<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let calldata_pointer_global = context.get_global(crate::eravm::GLOBAL_CALLDATA_POINTER)?;
     let calldata_pointer_pointer = calldata_pointer_global.into();
@@ -44,7 +44,7 @@ pub fn size<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let value = context.get_global_value(crate::eravm::GLOBAL_CALLDATA_SIZE)?;
 
@@ -61,7 +61,7 @@ pub fn copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination = Pointer::new_with_offset(
         context,

--- a/src/eravm/evm/comparison.rs
+++ b/src/eravm/evm/comparison.rs
@@ -20,7 +20,7 @@ pub fn compare<'ctx, D>(
     operation: inkwell::IntPredicate,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let result = context.builder().build_int_compare(
         operation,

--- a/src/eravm/evm/context.rs
+++ b/src/eravm/evm/context.rs
@@ -15,7 +15,7 @@ pub fn gas_limit<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -32,7 +32,7 @@ pub fn gas_price<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -49,7 +49,7 @@ pub fn origin<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -66,7 +66,7 @@ pub fn chain_id<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -83,7 +83,7 @@ pub fn block_number<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -100,7 +100,7 @@ pub fn block_timestamp<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -118,7 +118,7 @@ pub fn block_hash<'ctx, D>(
     index: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -135,7 +135,7 @@ pub fn difficulty<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -152,7 +152,7 @@ pub fn coinbase<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -169,7 +169,7 @@ pub fn basefee<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -186,7 +186,7 @@ pub fn msize<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let meta = context
         .build_call(context.intrinsics().meta, &[], "msize_meta")?

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -26,7 +26,7 @@ pub fn create<'ctx, D>(
     input_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let signature_hash_string =
         crate::eravm::utils::keccak256(crate::eravm::DEPLOYER_SIGNATURE_CREATE.as_bytes());
@@ -66,7 +66,7 @@ pub fn create2<'ctx, D>(
     salt: Option<inkwell::values::IntValue<'ctx>>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let signature_hash_string =
         crate::eravm::utils::keccak256(crate::eravm::DEPLOYER_SIGNATURE_CREATE2.as_bytes());
@@ -103,7 +103,7 @@ pub fn contract_hash<'ctx, D>(
     identifier: String,
 ) -> anyhow::Result<Value<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let code_type = context
         .code_type()
@@ -155,7 +155,7 @@ pub fn header_size<'ctx, D>(
     identifier: String,
 ) -> anyhow::Result<Value<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let code_type = context
         .code_type()

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -129,7 +129,7 @@ where
         anyhow::bail!("type({identifier}).runtimeCode is not supported");
     }
 
-    let hash_string = context.compile_dependency(identifier.as_str())?;
+    let hash_string = context.get_dependency_data(identifier.as_str())?;
     let hash_value = context
         .field_const_str_hex(hash_string.as_str())
         .as_basic_value_enum();

--- a/src/eravm/evm/crypto.rs
+++ b/src/eravm/evm/crypto.rs
@@ -19,7 +19,7 @@ pub fn sha3<'ctx, D>(
     length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let offset_pointer = context.builder().build_int_to_ptr(
         offset,

--- a/src/eravm/evm/ether_gas.rs
+++ b/src/eravm/evm/ether_gas.rs
@@ -13,7 +13,7 @@ pub fn gas<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().gas_left, &[], "gas_left")?
@@ -27,7 +27,7 @@ pub fn value<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().get_u128, &[], "get_u128_value")?
@@ -42,7 +42,7 @@ pub fn balance<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,

--- a/src/eravm/evm/event.rs
+++ b/src/eravm/evm/event.rs
@@ -25,7 +25,7 @@ pub fn log<'ctx, D>(
     topics: Vec<inkwell::values::IntValue<'ctx>>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let failure_block = context.append_basic_block("event_failure_block");
     let join_block = context.append_basic_block("event_join_block");

--- a/src/eravm/evm/ext_code.rs
+++ b/src/eravm/evm/ext_code.rs
@@ -14,7 +14,7 @@ pub fn size<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,
@@ -32,7 +32,7 @@ pub fn hash<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::call::request(
         context,

--- a/src/eravm/evm/immutable.rs
+++ b/src/eravm/evm/immutable.rs
@@ -20,7 +20,7 @@ pub fn load<'ctx, D>(
     index: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     match context.code_type() {
         None => {
@@ -83,7 +83,7 @@ pub fn store<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     match context.code_type() {
         None => {

--- a/src/eravm/evm/math.rs
+++ b/src/eravm/evm/math.rs
@@ -18,7 +18,7 @@ pub fn add_mod<'ctx, D>(
     modulo: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -43,7 +43,7 @@ pub fn mul_mod<'ctx, D>(
     modulo: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -67,7 +67,7 @@ pub fn exponent<'ctx, D>(
     exponent: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -87,7 +87,7 @@ pub fn sign_extend<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(

--- a/src/eravm/evm/memory.rs
+++ b/src/eravm/evm/memory.rs
@@ -20,7 +20,7 @@ pub fn load<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer = Pointer::new_with_offset(
         context,
@@ -44,7 +44,7 @@ pub fn store<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer = Pointer::new_with_offset(
         context,
@@ -68,7 +68,7 @@ pub fn store_byte<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let offset_pointer = Pointer::new_with_offset(
         context,

--- a/src/eravm/evm/return.rs
+++ b/src/eravm/evm/return.rs
@@ -20,7 +20,7 @@ pub fn r#return<'ctx, D>(
     length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     match context.code_type() {
         None => {
@@ -90,7 +90,7 @@ pub fn revert<'ctx, D>(
     length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_exit(context.llvm_runtime().revert, offset, length)?;
     Ok(())
@@ -103,7 +103,7 @@ where
 ///
 pub fn stop<D>(context: &mut Context<D>) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     r#return(context, context.field_const(0), context.field_const(0))
 }
@@ -115,7 +115,7 @@ where
 ///
 pub fn invalid<D>(context: &mut Context<D>) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     crate::eravm::evm::memory::store(
         context,

--- a/src/eravm/evm/return_data.rs
+++ b/src/eravm/evm/return_data.rs
@@ -18,7 +18,7 @@ pub fn size<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     match context.get_global_value(crate::eravm::GLOBAL_RETURN_DATA_SIZE) {
         Ok(global) => Ok(global),
@@ -36,7 +36,7 @@ pub fn copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let error_block = context.append_basic_block("return_data_copy_error_block");
     let join_block = context.append_basic_block("return_data_copy_join_block");

--- a/src/eravm/evm/storage.rs
+++ b/src/eravm/evm/storage.rs
@@ -16,7 +16,7 @@ pub fn load<'ctx, D>(
     position: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let position_pointer = Pointer::new_with_offset(
         context,
@@ -38,7 +38,7 @@ pub fn store<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let position_pointer = Pointer::new_with_offset(
         context,
@@ -59,7 +59,7 @@ pub fn transient_load<'ctx, D>(
     position: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let position_pointer = Pointer::new_with_offset(
         context,
@@ -81,7 +81,7 @@ pub fn transient_store<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let position_pointer = Pointer::new_with_offset(
         context,

--- a/src/eravm/extensions/abi.rs
+++ b/src/eravm/extensions/abi.rs
@@ -19,7 +19,7 @@ pub fn get_extra_abi_data<'ctx, D>(
     index: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let extra_active_data_global = context.get_global(crate::eravm::GLOBAL_EXTRA_ABI_DATA)?;
     let extra_active_data_pointer = extra_active_data_global.into();
@@ -43,7 +43,7 @@ pub fn calldata_ptr_to_active<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let calldata_pointer = context.get_global_value(crate::eravm::GLOBAL_CALLDATA_POINTER)?;
     context.set_active_pointer(
@@ -60,7 +60,7 @@ pub fn return_data_ptr_to_active<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let return_data_pointer = context.get_global_value(crate::eravm::GLOBAL_RETURN_DATA_POINTER)?;
     context.set_active_pointer(
@@ -77,7 +77,7 @@ pub fn decommit_ptr_to_active<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let decommit_pointer = context.get_global_value(crate::eravm::GLOBAL_DECOMMIT_POINTER)?;
     context.set_active_pointer(
@@ -95,7 +95,7 @@ pub fn active_ptr_add_assign<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     let active_pointer_shifted = context.build_gep(
@@ -116,7 +116,7 @@ pub fn active_ptr_shrink_assign<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     let active_pointer_shrunken = context
@@ -144,7 +144,7 @@ pub fn active_ptr_pack_assign<'ctx, D>(
     data: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     let active_pointer_packed = context
@@ -172,7 +172,7 @@ pub fn active_ptr_data_load<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     let active_pointer = context.build_gep(
@@ -192,7 +192,7 @@ pub fn active_ptr_data_size<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     let active_pointer_value = context.builder().build_ptr_to_int(
@@ -224,7 +224,7 @@ pub fn active_ptr_data_copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination = Pointer::new_with_offset(
         context,
@@ -259,7 +259,7 @@ pub fn active_ptr_return_forward<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     context.build_call(
@@ -278,7 +278,7 @@ pub fn active_ptr_revert_forward<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let active_pointer = context.get_active_pointer(context.field_const(0))?;
     context.build_call(
@@ -299,7 +299,7 @@ pub fn active_ptr_swap<'ctx, D>(
     index_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer_1 = context.get_active_pointer(index_1)?;
     let pointer_2 = context.get_active_pointer(index_2)?;

--- a/src/eravm/extensions/call.rs
+++ b/src/eravm/extensions/call.rs
@@ -25,7 +25,7 @@ pub fn mimic<'ctx, D>(
     extra_abi_data: Vec<inkwell::values::IntValue<'ctx>>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let status_code_result_pointer = context.build_alloca(
         context.field_type(),
@@ -99,7 +99,7 @@ pub fn raw_far<'ctx, D>(
     output_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let status_code_result_pointer = context.build_alloca(
         context.field_type(),
@@ -187,7 +187,7 @@ pub fn system<'ctx, D>(
     extra_abi_data: Vec<inkwell::values::IntValue<'ctx>>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let status_code_result_pointer = context.build_alloca(
         context.field_type(),

--- a/src/eravm/extensions/const_array.rs
+++ b/src/eravm/extensions/const_array.rs
@@ -19,7 +19,7 @@ pub fn declare<'ctx, D>(
     size: u16,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.yul_mut().const_array_declare(index, size)?;
 
@@ -36,7 +36,7 @@ pub fn set<'ctx, D>(
     value: num::BigUint,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.yul_mut().const_array_set(index, offset, value)?;
 
@@ -52,7 +52,7 @@ pub fn finalize<'ctx, D>(
     index: u8,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let const_array = context.yul_mut().const_array_take(index)?;
     let array_type = context.field_type().array_type(const_array.len() as u32);
@@ -88,7 +88,7 @@ pub fn get<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let identifier = format!(
         "{}{:03}",

--- a/src/eravm/extensions/general.rs
+++ b/src/eravm/extensions/general.rs
@@ -19,7 +19,7 @@ pub fn to_l1<'ctx, D>(
     in_1: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let join_block = context.append_basic_block("contract_call_toL1_join_block");
 
@@ -81,7 +81,7 @@ pub fn code_source<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let result = context
         .build_call(
@@ -102,7 +102,7 @@ pub fn precompile<'ctx, D>(
     gas_left: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let result = context
         .build_call(
@@ -123,7 +123,7 @@ pub fn decommit<'ctx, D>(
     gas_left: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let result = context
         .build_call(
@@ -148,7 +148,7 @@ pub fn meta<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let result = context
         .build_call(
@@ -168,7 +168,7 @@ pub fn set_context_value<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(
         context.intrinsics().set_u128,
@@ -186,7 +186,7 @@ pub fn set_pubdata_price<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(
         context.intrinsics().set_pubdata_price,
@@ -203,7 +203,7 @@ pub fn increment_tx_counter<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(
         context.intrinsics().increment_tx_counter,
@@ -223,7 +223,7 @@ pub fn event<'ctx, D>(
     is_initializer: bool,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(
         context.intrinsics().event,

--- a/src/eravm/extensions/math.rs
+++ b/src/eravm/extensions/math.rs
@@ -17,7 +17,7 @@ pub fn multiplication_512<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let operand_1_extended = context.builder().build_int_z_extend_or_bit_cast(
         operand_1,

--- a/src/eravm/mod.rs
+++ b/src/eravm/mod.rs
@@ -83,7 +83,7 @@ pub fn build_assembly_text(
 ///
 pub trait WriteLLVM<D>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     ///
     /// Declares the entity in the LLVM IR.
@@ -107,7 +107,7 @@ pub struct DummyLLVMWritable {}
 
 impl<D> WriteLLVM<D> for DummyLLVMWritable
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn into_llvm(self, _context: &mut Context<D>) -> anyhow::Result<()> {
         Ok(())

--- a/src/eravm/mod.rs
+++ b/src/eravm/mod.rs
@@ -12,7 +12,7 @@ pub mod utils;
 pub use self::r#const::*;
 
 use crate::debug_config::DebugConfig;
-use crate::optimizer::settings::Settings as OptimizerSettings;
+use crate::dependency::Dependency;
 
 use self::context::build::Build;
 use self::context::Context;
@@ -81,7 +81,6 @@ pub fn build_assembly_text(
 ///
 /// Implemented by items which are translated into LLVM IR.
 ///
-#[allow(clippy::upper_case_acronyms)]
 pub trait WriteLLVM<D>
 where
     D: Dependency + Clone,
@@ -112,67 +111,5 @@ where
 {
     fn into_llvm(self, _context: &mut Context<D>) -> anyhow::Result<()> {
         Ok(())
-    }
-}
-
-///
-/// Implemented by items managing project dependencies.
-///
-pub trait Dependency {
-    ///
-    /// Compiles a project dependency.
-    ///
-    fn compile(
-        dependency: Self,
-        path: &str,
-        optimizer_settings: OptimizerSettings,
-        llvm_options: &[String],
-        enable_eravm_extensions: bool,
-        include_metadata_hash: bool,
-        debug_config: Option<DebugConfig>,
-    ) -> anyhow::Result<String>;
-
-    ///
-    /// Resolves a full contract path.
-    ///
-    fn resolve_path(&self, identifier: &str) -> anyhow::Result<String>;
-
-    ///
-    /// Resolves a library address.
-    ///
-    fn resolve_library(&self, path: &str) -> anyhow::Result<String>;
-}
-
-///
-/// The dummy dependency entity.
-///
-#[derive(Debug, Default, Clone)]
-pub struct DummyDependency {}
-
-impl Dependency for DummyDependency {
-    fn compile(
-        _dependency: Self,
-        _path: &str,
-        _optimizer_settings: OptimizerSettings,
-        _llvm_options: &[String],
-        _enable_eravm_extensions: bool,
-        _include_metadata_hash: bool,
-        _debug_config: Option<DebugConfig>,
-    ) -> anyhow::Result<String> {
-        Ok(String::new())
-    }
-
-    ///
-    /// Resolves a full contract path.
-    ///
-    fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
-        Ok(String::new())
-    }
-
-    ///
-    /// Resolves a library address.
-    ///
-    fn resolve_library(&self, _path: &str) -> anyhow::Result<String> {
-        Ok(String::new())
     }
 }

--- a/src/eravm/utils.rs
+++ b/src/eravm/utils.rs
@@ -21,7 +21,7 @@ pub fn clamp<'ctx, D>(
     name: &str,
 ) -> anyhow::Result<inkwell::values::IntValue<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let in_bounds_block = context.append_basic_block(format!("{name}_is_bounds_block").as_str());
     let join_block = context.append_basic_block(format!("{name}_join_block").as_str());
@@ -51,7 +51,7 @@ where
 ///
 pub fn throw<D>(context: &Context<D>) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(
         context.llvm_runtime().cxa_throw,
@@ -78,7 +78,7 @@ pub fn external_call_arguments<'ctx, D>(
     mimic: Option<inkwell::values::IntValue<'ctx>>,
 ) -> Vec<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let mut result = Vec::with_capacity(
         crate::eravm::context::function::runtime::entry::Entry::MANDATORY_ARGUMENTS_COUNT
@@ -112,7 +112,7 @@ pub fn abi_data<'ctx, D>(
     is_system_call: bool,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset = crate::eravm::utils::clamp(
         context,
@@ -201,7 +201,7 @@ pub fn pad_extra_abi_data<'ctx, D>(
     initial_data: Vec<inkwell::values::IntValue<'ctx>>,
 ) -> [inkwell::values::IntValue<'ctx>; crate::eravm::EXTRA_ABI_DATA_SIZE]
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let mut padded_data = initial_data;
     padded_data.extend(vec![

--- a/src/evm/context/function/runtime/entry.rs
+++ b/src/evm/context/function/runtime/entry.rs
@@ -18,7 +18,7 @@ use crate::evm::WriteLLVM;
 pub struct Entry<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     /// The runtime code AST representation.
     inner: B,
@@ -29,7 +29,7 @@ where
 impl<B, D> Entry<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     ///
     /// A shortcut constructor.
@@ -45,7 +45,7 @@ where
 impl<B, D> WriteLLVM<D> for Entry<B, D>
 where
     B: WriteLLVM<D>,
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn declare(&mut self, context: &mut Context<D>) -> anyhow::Result<()> {
         let function_type = context.function_type::<inkwell::types::BasicTypeEnum>(vec![], 0);

--- a/src/evm/instructions/arithmetic.rs
+++ b/src/evm/instructions/arithmetic.rs
@@ -19,7 +19,7 @@ pub fn addition<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -38,7 +38,7 @@ pub fn subtraction<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -57,7 +57,7 @@ pub fn multiplication<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -77,7 +77,7 @@ pub fn division<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let zero_block = context.append_basic_block("division_zero");
     let non_zero_block = context.append_basic_block("division_non_zero");
@@ -122,7 +122,7 @@ pub fn remainder<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let zero_block = context.append_basic_block("remainder_zero");
     let non_zero_block = context.append_basic_block("remainder_non_zero");
@@ -168,7 +168,7 @@ pub fn division_signed<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let zero_block = context.append_basic_block("division_signed_zero");
     let non_zero_block = context.append_basic_block("division_signed_non_zero");
@@ -242,7 +242,7 @@ pub fn remainder_signed<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let zero_block = context.append_basic_block("remainder_signed_zero");
     let non_zero_block = context.append_basic_block("remainder_signed_non_zero");

--- a/src/evm/instructions/bitwise.rs
+++ b/src/evm/instructions/bitwise.rs
@@ -17,7 +17,7 @@ pub fn or<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -34,7 +34,7 @@ pub fn xor<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -51,7 +51,7 @@ pub fn and<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .builder()
@@ -71,7 +71,7 @@ pub fn shift_left<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let overflow_block = context.append_basic_block("shift_left_overflow");
     let non_overflow_block = context.append_basic_block("shift_left_non_overflow");
@@ -116,7 +116,7 @@ pub fn shift_right<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let overflow_block = context.append_basic_block("shift_right_overflow");
     let non_overflow_block = context.append_basic_block("shift_right_non_overflow");
@@ -163,7 +163,7 @@ pub fn shift_right_arithmetic<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let overflow_block = context.append_basic_block("shift_right_arithmetic_overflow");
     let overflow_positive_block =
@@ -235,7 +235,7 @@ pub fn byte<'ctx, D>(
     operand_2: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(

--- a/src/evm/instructions/call.rs
+++ b/src/evm/instructions/call.rs
@@ -26,7 +26,7 @@ pub fn call<'ctx, D>(
     output_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,
@@ -74,7 +74,7 @@ pub fn static_call<'ctx, D>(
     output_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,
@@ -121,7 +121,7 @@ pub fn delegate_call<'ctx, D>(
     output_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,
@@ -162,7 +162,7 @@ pub fn linker_symbol<'ctx, D>(
     mut arguments: [Value<'ctx>; 1],
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let path = arguments[0]
         .original

--- a/src/evm/instructions/calldata.rs
+++ b/src/evm/instructions/calldata.rs
@@ -16,7 +16,7 @@ pub fn load<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer = Pointer::new_with_offset(
         context,
@@ -36,7 +36,7 @@ pub fn size<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().calldatasize, &[], "calldatasize")?
@@ -53,7 +53,7 @@ pub fn copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination = Pointer::new_with_offset(
         context,

--- a/src/evm/instructions/code.rs
+++ b/src/evm/instructions/code.rs
@@ -17,7 +17,7 @@ pub fn size<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().codesize, &[], "codesize")?
@@ -34,7 +34,7 @@ pub fn copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination = Pointer::new_with_offset(
         context,
@@ -70,7 +70,7 @@ pub fn ext_size<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -92,7 +92,7 @@ pub fn ext_copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination_offset_pointer = Pointer::new_with_offset(
         context,
@@ -125,7 +125,7 @@ pub fn ext_hash<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(

--- a/src/evm/instructions/comparison.rs
+++ b/src/evm/instructions/comparison.rs
@@ -20,7 +20,7 @@ pub fn compare<'ctx, D>(
     operation: inkwell::IntPredicate,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let result = context.builder().build_int_compare(
         operation,

--- a/src/evm/instructions/context.rs
+++ b/src/evm/instructions/context.rs
@@ -15,7 +15,7 @@ pub fn gas_limit<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().gaslimit, &[], "gaslimit")?
@@ -29,7 +29,7 @@ pub fn gas_price<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().gasprice, &[], "gasprice")?
@@ -43,7 +43,7 @@ pub fn origin<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().origin, &[], "origin")?
@@ -57,7 +57,7 @@ pub fn chain_id<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().chainid, &[], "chainid")?
@@ -71,7 +71,7 @@ pub fn block_number<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().number, &[], "number")?
@@ -85,7 +85,7 @@ pub fn block_timestamp<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().timestamp, &[], "timestamp")?
@@ -100,7 +100,7 @@ pub fn block_hash<'ctx, D>(
     index: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -118,7 +118,7 @@ pub fn difficulty<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().difficulty, &[], "difficulty")?
@@ -132,7 +132,7 @@ pub fn coinbase<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().coinbase, &[], "coinbase")?
@@ -146,7 +146,7 @@ pub fn basefee<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().basefee, &[], "basefee")?
@@ -160,7 +160,7 @@ pub fn msize<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().msize, &[], "msize")?

--- a/src/evm/instructions/create.rs
+++ b/src/evm/instructions/create.rs
@@ -20,7 +20,7 @@ pub fn create<'ctx, D>(
     input_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,
@@ -54,7 +54,7 @@ pub fn create2<'ctx, D>(
     salt: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,

--- a/src/evm/instructions/ether_gas.rs
+++ b/src/evm/instructions/ether_gas.rs
@@ -15,7 +15,7 @@ pub fn gas<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().gas, &[], "gas")?
@@ -29,7 +29,7 @@ pub fn callvalue<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().callvalue, &[], "callvalue")?
@@ -44,7 +44,7 @@ pub fn balance<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -62,7 +62,7 @@ pub fn self_balance<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().selfbalance, &[], "selfbalance")?
@@ -77,7 +77,7 @@ pub fn self_destruct<'ctx, D>(
     address: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(

--- a/src/evm/instructions/event.rs
+++ b/src/evm/instructions/event.rs
@@ -20,7 +20,7 @@ pub fn log<'ctx, D>(
     input_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,

--- a/src/evm/instructions/immutable.rs
+++ b/src/evm/instructions/immutable.rs
@@ -13,7 +13,7 @@ pub fn load<'ctx, D>(
     _index: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     todo!()
 }
@@ -27,7 +27,7 @@ pub fn store<'ctx, D>(
     _value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     todo!()
 }

--- a/src/evm/instructions/math.rs
+++ b/src/evm/instructions/math.rs
@@ -20,7 +20,7 @@ pub fn add_mod<'ctx, D>(
     modulo: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -45,7 +45,7 @@ pub fn mul_mod<'ctx, D>(
     modulo: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -69,7 +69,7 @@ pub fn exponent<'ctx, D>(
     exponent: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -89,7 +89,7 @@ pub fn sign_extend<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(
@@ -109,7 +109,7 @@ pub fn keccak256<'ctx, D>(
     input_length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let input_offset_pointer = Pointer::new_with_offset(
         context,

--- a/src/evm/instructions/memory.rs
+++ b/src/evm/instructions/memory.rs
@@ -20,7 +20,7 @@ pub fn load<'ctx, D>(
     offset: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer = Pointer::new_with_offset(
         context,
@@ -44,7 +44,7 @@ pub fn store<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer = Pointer::new_with_offset(
         context,
@@ -68,7 +68,7 @@ pub fn store_byte<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let pointer = Pointer::new_with_offset(
         context,

--- a/src/evm/instructions/return.rs
+++ b/src/evm/instructions/return.rs
@@ -19,7 +19,7 @@ pub fn r#return<'ctx, D>(
     length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let offset_pointer = Pointer::new_with_offset(
         context,
@@ -50,7 +50,7 @@ pub fn revert<'ctx, D>(
     length: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let offset_pointer = Pointer::new_with_offset(
         context,
@@ -77,7 +77,7 @@ where
 ///
 pub fn stop<D>(context: &mut Context<D>) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(context.intrinsics().stop, &[], "stop")?;
     context.build_unreachable()?;
@@ -89,7 +89,7 @@ where
 ///
 pub fn invalid<D>(context: &mut Context<D>) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     context.build_call(context.intrinsics().invalid, &[], "invalid")?;
     context.build_unreachable()?;

--- a/src/evm/instructions/return_data.rs
+++ b/src/evm/instructions/return_data.rs
@@ -15,7 +15,7 @@ pub fn size<'ctx, D>(
     context: &mut Context<'ctx, D>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     Ok(context
         .build_call(context.intrinsics().returndatasize, &[], "returndatasize")?
@@ -32,7 +32,7 @@ pub fn copy<'ctx, D>(
     size: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let destination = Pointer::new_with_offset(
         context,

--- a/src/evm/instructions/storage.rs
+++ b/src/evm/instructions/storage.rs
@@ -16,7 +16,7 @@ pub fn load<'ctx, D>(
     position: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let position_pointer = Pointer::new_with_offset(
         context,
@@ -38,7 +38,7 @@ pub fn store<'ctx, D>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     let position_pointer = Pointer::new_with_offset(
         context,

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -22,7 +22,7 @@ pub fn initialize_target() {
 ///
 pub trait WriteLLVM<D>
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     ///
     /// Declares the entity in the LLVM IR.
@@ -46,7 +46,7 @@ pub struct DummyLLVMWritable {}
 
 impl<D> WriteLLVM<D> for DummyLLVMWritable
 where
-    D: Dependency + Clone,
+    D: Dependency,
 {
     fn into_llvm(self, _context: &mut Context<D>) -> anyhow::Result<()> {
         Ok(())

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -6,8 +6,7 @@ pub mod r#const;
 pub mod context;
 pub mod instructions;
 
-use crate::debug_config::DebugConfig;
-use crate::optimizer::settings::Settings as OptimizerSettings;
+use crate::dependency::Dependency;
 
 use self::context::Context;
 
@@ -21,7 +20,6 @@ pub fn initialize_target() {
 ///
 /// Implemented by items which are translated into LLVM IR.
 ///
-#[allow(clippy::upper_case_acronyms)]
 pub trait WriteLLVM<D>
 where
     D: Dependency + Clone,
@@ -52,65 +50,5 @@ where
 {
     fn into_llvm(self, _context: &mut Context<D>) -> anyhow::Result<()> {
         Ok(())
-    }
-}
-
-///
-/// Implemented by items managing project dependencies.
-///
-pub trait Dependency {
-    ///
-    /// Compiles a project dependency.
-    ///
-    fn compile(
-        dependency: Self,
-        path: &str,
-        optimizer_settings: OptimizerSettings,
-        llvm_options: &[String],
-        include_metadata_hash: bool,
-        debug_config: Option<DebugConfig>,
-    ) -> anyhow::Result<String>;
-
-    ///
-    /// Resolves a full contract path.
-    ///
-    fn resolve_path(&self, identifier: &str) -> anyhow::Result<String>;
-
-    ///
-    /// Resolves a library address.
-    ///
-    fn resolve_library(&self, path: &str) -> anyhow::Result<String>;
-}
-
-///
-/// The dummy dependency entity.
-///
-#[derive(Debug, Default, Clone)]
-pub struct DummyDependency {}
-
-impl Dependency for DummyDependency {
-    fn compile(
-        _dependency: Self,
-        _path: &str,
-        _optimizer_settings: OptimizerSettings,
-        _llvm_options: &[String],
-        _include_metadata_hash: bool,
-        _debug_config: Option<DebugConfig>,
-    ) -> anyhow::Result<String> {
-        Ok(String::new())
-    }
-
-    ///
-    /// Resolves a full contract path.
-    ///
-    fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
-        Ok(String::new())
-    }
-
-    ///
-    /// Resolves a library address.
-    ///
-    fn resolve_library(&self, _path: &str) -> anyhow::Result<String> {
-        Ok(String::new())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@
 //!
 
 #![allow(clippy::too_many_arguments)]
+#![allow(clippy::upper_case_acronyms)]
 
 pub(crate) mod r#const;
 pub(crate) mod context;
 pub(crate) mod debug_config;
 pub(crate) mod debug_info;
+pub(crate) mod dependency;
 pub(crate) mod eravm;
 pub(crate) mod evm;
 pub(crate) mod optimizer;
@@ -32,6 +34,8 @@ pub use self::context::IContext;
 pub use self::debug_config::ir_type::IRType as DebugConfigIR;
 pub use self::debug_config::DebugConfig;
 pub use self::debug_info::DebugInfo;
+pub use self::dependency::Dependency;
+pub use self::dependency::DummyDependency;
 pub use self::eravm::build_assembly_text as eravm_build_assembly_text;
 pub use self::eravm::context::address_space::AddressSpace as EraVMAddressSpace;
 pub use self::eravm::context::build::Build as EraVMBuild;
@@ -74,8 +78,6 @@ pub use self::eravm::extensions::math as eravm_math;
 pub use self::eravm::metadata_hash::MetadataHash as EraVMMetadataHash;
 pub use self::eravm::r#const as eravm_const;
 pub use self::eravm::utils as eravm_utils;
-pub use self::eravm::Dependency as EraVMDependency;
-pub use self::eravm::DummyDependency as EraVMDummyDependency;
 pub use self::eravm::DummyLLVMWritable as EraVMDummyLLVMWritable;
 pub use self::eravm::WriteLLVM as EraVMWriteLLVM;
 pub use self::evm::context::address_space::AddressSpace as EVMAddressSpace;
@@ -103,8 +105,6 @@ pub use self::evm::instructions::r#return as evm_return;
 pub use self::evm::instructions::return_data as evm_return_data;
 pub use self::evm::instructions::storage as evm_storage;
 pub use self::evm::r#const as evm_const;
-pub use self::evm::Dependency as EVMDependency;
-pub use self::evm::DummyDependency as EVMDummyDependency;
 pub use self::evm::DummyLLVMWritable as EVMDummyLLVMWritable;
 pub use self::evm::WriteLLVM as EVMWriteLLVM;
 pub use self::optimizer::settings::size_level::SizeLevel as OptimizerSettingsSizeLevel;


### PR DESCRIPTION
# What ❔

1. Writes all remaining errors to standard JSON, including:
    - file opening and reading
    - IR parsing
2. Reads the input stdin without a reader as it is known to be slower.
3. Optimizes the dependency graph so some contracts are not compiled twice.

## Why ❔

1. Some contract-specific errors are still printed to stderr.
2. AAVE still experiences insane compilation times.
3. AAVE still experiences insane compilation times.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
