### PR TITLE
feat: set noinline attribute for all calls in -O0

### DIFF
--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -997,6 +997,13 @@ where
             arguments_wrapped.as_slice(),
             name,
         )?;
+        if self.optimizer.settings().level_middle_end == inkwell::OptimizationLevel::None {
+            call_site_value.add_attribute(
+                inkwell::attributes::AttributeLoc::Function,
+                self.llvm
+                    .create_enum_attribute(Attribute::NoInline as u32, 0),
+            );
+        }
         self.modify_call_site_value(arguments, call_site_value, function);
         Ok(call_site_value.try_as_basic_value().left())
     }


### PR DESCRIPTION
# What ❔

Sets the `noinline` attribute for all calls in `-O0`.

## Why ❔

It will prevent inlining of some runtime functions with `alwaysinline` attribute.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
