### PR TITLE
fix: linker API integer types

### DIFF
--- a/src/eravm/const.rs
+++ b/src/eravm/const.rs
@@ -64,7 +64,7 @@ pub const NO_SYSTEM_CALL_BIT: bool = false;
 pub const SYSTEM_CALL_BIT: bool = true;
 
 /// The default disassembler mode.
-pub const DISASSEMBLER_DEFAULT_MODE: u32 = 1;
+pub const DISASSEMBLER_DEFAULT_MODE: u64 = 1;
 
 ///
 /// The deployer call header size that consists of:

--- a/src/target_machine.rs
+++ b/src/target_machine.rs
@@ -90,8 +90,8 @@ impl TargetMachine {
     pub fn disassemble(
         &self,
         memory_buffer: &inkwell::memory_buffer::MemoryBuffer,
-        pc: u32,
-        options: u32,
+        pc: u64,
+        options: u64,
     ) -> Result<inkwell::memory_buffer::MemoryBuffer, inkwell::support::LLVMString> {
         memory_buffer.disassemble_eravm(&self.target_machine, pc, options)
     }


### PR DESCRIPTION
# What ❔

Fixes some API types by making them 64 bits.

## Why ❔

Most of them turned out to be incorrect.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
