### PR TITLE
fix: memcpy and event intrinsic argument order

### DIFF
--- a/src/eravm/context/function/intrinsics.rs
+++ b/src/eravm/context/function/intrinsics.rs
@@ -66,7 +66,7 @@ impl<'ctx> Intrinsics<'ctx> {
     pub const FUNCTION_MEMORY_MOVE: &'static str = "llvm.memmove.p1.p1.i256";
 
     /// The corresponding intrinsic function name.
-    pub const FUNCTION_MEMORY_COPY_FROM_GENERIC: &'static str = "llvm.memcpy.p3.p1.i256";
+    pub const FUNCTION_MEMORY_COPY_FROM_GENERIC: &'static str = "llvm.memcpy.p1.p3.i256";
 
     /// The corresponding intrinsic function name.
     pub const FUNCTION_LINKER_SYMBOL: &'static str = "llvm.eravm.linkersymbol";

--- a/src/evm/context/function/intrinsics.rs
+++ b/src/evm/context/function/intrinsics.rs
@@ -277,13 +277,13 @@ impl<'ctx> Intrinsics<'ctx> {
     pub const FUNCTION_MEMORY_COPY_FROM_HEAP: &'static str = "llvm.memcpy.p1.p1.i256";
 
     /// The corresponding intrinsic function name.
-    pub const FUNCTION_MEMORY_COPY_FROM_CALLDATA: &'static str = "llvm.memcpy.p2.p1.i256";
+    pub const FUNCTION_MEMORY_COPY_FROM_CALLDATA: &'static str = "llvm.memcpy.p1.p2.i256";
 
     /// The corresponding intrinsic function name.
-    pub const FUNCTION_MEMORY_COPY_FROM_RETURN_DATA: &'static str = "llvm.memcpy.p3.p1.i256";
+    pub const FUNCTION_MEMORY_COPY_FROM_RETURN_DATA: &'static str = "llvm.memcpy.p1.p3.i256";
 
     /// The corresponding intrinsic function name.
-    pub const FUNCTION_MEMORY_COPY_FROM_CODE: &'static str = "llvm.memcpy.p4.p1.i256";
+    pub const FUNCTION_MEMORY_COPY_FROM_CODE: &'static str = "llvm.memcpy.p1.p4.i256";
 
     ///
     /// A shortcut constructor.

--- a/src/evm/instructions/event.rs
+++ b/src/evm/instructions/event.rs
@@ -15,9 +15,9 @@ use crate::evm::Dependency;
 ///
 pub fn log<'ctx, D>(
     context: &mut Context<'ctx, D>,
-    topics: Vec<inkwell::values::IntValue<'ctx>>,
     input_offset: inkwell::values::IntValue<'ctx>,
     input_length: inkwell::values::IntValue<'ctx>,
+    topics: Vec<inkwell::values::IntValue<'ctx>>,
 ) -> anyhow::Result<()>
 where
     D: Dependency,
@@ -42,42 +42,42 @@ where
         1 => context.build_call(
             context.intrinsics().log1,
             &[
-                topics[0].as_basic_value_enum(),
                 input_offset_pointer.as_basic_value_enum(),
                 input_length.as_basic_value_enum(),
+                topics[0].as_basic_value_enum(),
             ],
             "log1",
         ),
         2 => context.build_call(
             context.intrinsics().log2,
             &[
-                topics[0].as_basic_value_enum(),
-                topics[1].as_basic_value_enum(),
                 input_offset_pointer.as_basic_value_enum(),
                 input_length.as_basic_value_enum(),
+                topics[0].as_basic_value_enum(),
+                topics[1].as_basic_value_enum(),
             ],
             "log2",
         ),
         3 => context.build_call(
             context.intrinsics().log3,
             &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
                 topics[0].as_basic_value_enum(),
                 topics[1].as_basic_value_enum(),
                 topics[2].as_basic_value_enum(),
-                input_offset_pointer.as_basic_value_enum(),
-                input_length.as_basic_value_enum(),
             ],
             "log3",
         ),
         4 => context.build_call(
             context.intrinsics().log4,
             &[
+                input_offset_pointer.as_basic_value_enum(),
+                input_length.as_basic_value_enum(),
                 topics[0].as_basic_value_enum(),
                 topics[1].as_basic_value_enum(),
                 topics[2].as_basic_value_enum(),
                 topics[3].as_basic_value_enum(),
-                input_offset_pointer.as_basic_value_enum(),
-                input_length.as_basic_value_enum(),
             ],
             "log4",
         ),


### PR DESCRIPTION
# What ❔

1. Memcpy declaration pointer order.
2. Event intrinsics argument order.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
