### PR TITLE
fix: the zkevm_opcode_defs dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "=1.0.210", "features" = [ "derive" ] }
 num = "=0.4.3"
 itertools = "=0.13.0"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", version = "=0.150.5" }
+zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 


### PR DESCRIPTION
# What ❔

Removes the `git` reference from `zkevm_opcode_defs` dependency.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
