### PR TITLE
fix: library linking time indeterminism

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -15,11 +15,6 @@ pub trait Dependency {
     /// Resolves a full contract path.
     ///
     fn resolve_path(&self, identifier: &str) -> anyhow::Result<String>;
-
-    ///
-    /// Resolves a library address.
-    ///
-    fn resolve_library(&self, path: &str) -> Option<String>;
 }
 
 ///
@@ -38,12 +33,5 @@ impl Dependency for DummyDependency {
     ///
     fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
         Ok(String::new())
-    }
-
-    ///
-    /// Resolves a library address.
-    ///
-    fn resolve_library(&self, _path: &str) -> Option<String> {
-        None
     }
 }

--- a/src/eravm/mod.rs
+++ b/src/eravm/mod.rs
@@ -116,6 +116,7 @@ pub fn link(
 ///
 pub fn build(
     bytecode_buffer: inkwell::memory_buffer::MemoryBuffer,
+    linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
     metadata_hash: Option<era_compiler_common::Hash>,
     assembly_text: Option<String>,
 ) -> anyhow::Result<Build> {
@@ -130,7 +131,7 @@ pub fn build(
         None => bytecode_buffer,
     };
     let (bytecode_buffer_linked, bytecode_hash) =
-        self::link(bytecode_buffer_with_metadata, &BTreeMap::new())?;
+        self::link(bytecode_buffer_with_metadata, linker_symbols)?;
     let bytecode = bytecode_buffer_linked.as_slice().to_vec();
 
     let build = Build::new(bytecode, bytecode_hash, metadata_hash, assembly_text);

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -214,25 +214,6 @@ where
     }
 
     ///
-    /// Gets a deployed library address from the dependency manager.
-    ///
-    pub fn resolve_library(
-        &self,
-        identifier: &str,
-    ) -> anyhow::Result<inkwell::values::IntValue<'ctx>> {
-        self.dependency_manager
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("The dependency manager is unset"))
-            .and_then(|manager| {
-                let address = manager
-                    .resolve_library(identifier)
-                    .ok_or_else(|| anyhow::anyhow!("Could not resolve library `{identifier}"))?;
-                let address = self.field_const_str_hex(address.as_str());
-                Ok(address)
-            })
-    }
-
-    ///
     /// Returns a Yul function type with the specified arguments and number of return values.
     ///
     pub fn function_type<T>(

--- a/src/evm/instructions/call.rs
+++ b/src/evm/instructions/call.rs
@@ -158,18 +158,11 @@ where
 /// Translates the Yul `linkersymbol` instruction.
 ///
 pub fn linker_symbol<'ctx, D>(
-    context: &mut Context<'ctx, D>,
-    mut arguments: [Value<'ctx>; 1],
+    _context: &mut Context<'ctx, D>,
+    mut _arguments: [Value<'ctx>; 1],
 ) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
 where
     D: Dependency,
 {
-    let path = arguments[0]
-        .original
-        .take()
-        .ok_or_else(|| anyhow::anyhow!("Linker symbol literal is missing"))?;
-
-    Ok(context
-        .resolve_library(path.as_str())?
-        .as_basic_value_enum())
+    unimplemented!()
 }


### PR DESCRIPTION
# What ❔

Fixes the library linking indeterminism.

## Why ❔

The bytecode is not equal depending on when libraries are linked: at compile time or deploy (post-compile) time.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
