### PR TITLE
fix(eravm): resets return data after calling CREATE

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,10 @@
-all-features = false
-no-default-features = false
-
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "warn"
-notice = "warn"
 ignore = [
     #"RUSTSEC-0000-0000",
 ]
 
 [licenses]
-unlicensed = "deny"
 allow = [
     #"Apache-2.0 WITH LLVM-exception",
     "MIT",
@@ -20,17 +13,12 @@ allow = [
     "Unlicense",
     "MPL-2.0",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "CC0-1.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "Zlib",
 ]
-deny = [
-    #"Nokia",
-]
-copyleft = "warn"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 exceptions = [
     # Each entry is the crate and version constraint, and its specific allow

--- a/src/eravm/context/function/runtime/entry.rs
+++ b/src/eravm/context/function/runtime/entry.rs
@@ -156,26 +156,12 @@ where
         );
         context.write_abi_pointer(calldata_abi_pointer, crate::eravm::GLOBAL_CALLDATA_POINTER)?;
         context.write_abi_data_size(calldata_abi_pointer, crate::eravm::GLOBAL_CALLDATA_SIZE)?;
-        let calldata_length = context.get_global_value(crate::eravm::GLOBAL_CALLDATA_SIZE)?;
-        let calldata_end_pointer = context.build_gep(
-            calldata_abi_pointer,
-            &[calldata_length.into_int_value()],
-            context
-                .ptr_type(AddressSpace::Generic.into())
-                .as_basic_type_enum(),
-            "return_data_abi_initializer",
-        )?;
-        context.write_abi_pointer(
-            calldata_end_pointer,
+
+        context.reset_named_pointers(&[
             crate::eravm::GLOBAL_RETURN_DATA_POINTER,
-        )?;
-        context.write_abi_pointer(calldata_end_pointer, crate::eravm::GLOBAL_DECOMMIT_POINTER)?;
-        for index in 0..crate::eravm_const::AVAILABLE_ACTIVE_POINTERS_NUMBER {
-            context.set_active_pointer(
-                context.field_const(index as u64),
-                calldata_end_pointer.value,
-            )?;
-        }
+            crate::eravm::GLOBAL_DECOMMIT_POINTER,
+        ])?;
+        context.reset_active_pointers()?;
 
         let call_flags = context
             .current_function()

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -48,6 +48,14 @@ where
         )?
         .expect("Always exists");
 
+    context.reset_named_pointers(&[crate::eravm::GLOBAL_RETURN_DATA_POINTER])?;
+    context.set_global(
+        crate::eravm::GLOBAL_RETURN_DATA_SIZE,
+        context.field_type(),
+        AddressSpace::Stack,
+        context.field_const(0),
+    )?;
+
     Ok(result)
 }
 
@@ -87,6 +95,14 @@ where
             "create2_deployer_call",
         )?
         .expect("Always exists");
+
+    context.reset_named_pointers(&[crate::eravm::GLOBAL_RETURN_DATA_POINTER])?;
+    context.set_global(
+        crate::eravm::GLOBAL_RETURN_DATA_SIZE,
+        context.field_type(),
+        AddressSpace::Stack,
+        context.field_const(0),
+    )?;
 
     Ok(result)
 }


### PR DESCRIPTION
# What ❔

Cleares return data after calling `CREATE`/`CREATE2` (`ContractDeployer` system contract for EraVM).

## Why ❔

It is cleared on EVM, but not on EraVM.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
