### PR TITLE
feat(eravm): linkage of factory dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,19 +36,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Checkout LLVM
-        uses: actions/checkout@v4
-        with:
-          repository: matter-labs/era-compiler-llvm
-          ref: main
-          path: llvm
-
       - name: Build LLVM
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
         with:
           build-type: 'RelWithDebInfo'
           enable-assertions: true
-          clone-llvm: false
 
       - name: Run tests
         uses: matter-labs/era-compiler-ci/.github/actions/rust-unit-tests@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-commo
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "az-link-factory-dependencies"
+branch = "llvm-17"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-commo
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "llvm-17"
+branch = "az-link-factory-dependencies"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]

--- a/LLVM.lock
+++ b/LLVM.lock
@@ -1,2 +1,2 @@
 url = "https://github.com/matter-labs/era-compiler-llvm"
-branch = "kpv-eravm-factory-dependency"
+branch = "main"

--- a/LLVM.lock
+++ b/LLVM.lock
@@ -1,0 +1,2 @@
+url = "https://github.com/matter-labs/era-compiler-llvm"
+branch = "kpv-eravm-factory-dependency"

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -510,7 +510,7 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the Solidity data has not been initialized.
     ///
-    fn solidity(&self) -> &Self::SolidityData;
+    fn solidity(&self) -> Option<&Self::SolidityData>;
 
     ///
     /// Returns the Solidity data mutable reference.
@@ -518,7 +518,7 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the Solidity data has not been initialized.
     ///
-    fn solidity_mut(&mut self) -> &mut Self::SolidityData;
+    fn solidity_mut(&mut self) -> Option<&mut Self::SolidityData>;
 
     ///
     /// Sets the Yul data.
@@ -531,7 +531,7 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the Yul data has not been initialized.
     ///
-    fn yul(&self) -> &Self::YulData;
+    fn yul(&self) -> Option<&Self::YulData>;
 
     ///
     /// Returns the Yul data mutable reference.
@@ -539,7 +539,7 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the Yul data has not been initialized.
     ///
-    fn yul_mut(&mut self) -> &mut Self::YulData;
+    fn yul_mut(&mut self) -> Option<&mut Self::YulData>;
 
     ///
     /// Sets the EVM legacy assembly data.
@@ -552,7 +552,7 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the EVM data has not been initialized.
     ///
-    fn evmla(&self) -> &Self::EVMLAData;
+    fn evmla(&self) -> Option<&Self::EVMLAData>;
 
     ///
     /// Returns the EVM legacy assembly data mutable reference.
@@ -560,7 +560,7 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the EVM data has not been initialized.
     ///
-    fn evmla_mut(&mut self) -> &mut Self::EVMLAData;
+    fn evmla_mut(&mut self) -> Option<&mut Self::EVMLAData>;
 
     ///
     /// Sets the EVM legacy assembly data.
@@ -573,5 +573,13 @@ pub trait IContext<'ctx> {
     /// # Panics
     /// If the Vyper data has not been initialized.
     ///
-    fn vyper(&self) -> &Self::VyperData;
+    fn vyper(&self) -> Option<&Self::VyperData>;
+
+    ///
+    /// Returns the Vyper data mutable reference.
+    ///
+    /// # Panics
+    /// If the Vyper data has not been initialized.
+    ///
+    fn vyper_mut(&mut self) -> Option<&mut Self::VyperData>;
 }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -9,7 +9,7 @@ pub trait Dependency {
     ///
     /// Gets the data of the specified dependency.
     ///
-    fn get(&self, path: &str) -> anyhow::Result<String>;
+    fn get_data(&self, path: &str) -> anyhow::Result<Option<String>>;
 
     ///
     /// Resolves a full contract path.
@@ -24,8 +24,8 @@ pub trait Dependency {
 pub struct DummyDependency {}
 
 impl Dependency for DummyDependency {
-    fn get(&self, _path: &str) -> anyhow::Result<String> {
-        Ok(String::new())
+    fn get_data(&self, _path: &str) -> anyhow::Result<Option<String>> {
+        Ok(None)
     }
 
     ///

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -7,11 +7,6 @@
 ///
 pub trait Dependency {
     ///
-    /// Gets the data of the specified dependency.
-    ///
-    fn get_data(&self, path: &str) -> anyhow::Result<Option<String>>;
-
-    ///
     /// Resolves a full contract path.
     ///
     fn resolve_path(&self, identifier: &str) -> anyhow::Result<String>;
@@ -24,13 +19,6 @@ pub trait Dependency {
 pub struct DummyDependency {}
 
 impl Dependency for DummyDependency {
-    fn get_data(&self, _path: &str) -> anyhow::Result<Option<String>> {
-        Ok(None)
-    }
-
-    ///
-    /// Resolves a full contract path.
-    ///
     fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
         Ok(String::new())
     }

--- a/src/eravm/const.rs
+++ b/src/eravm/const.rs
@@ -5,6 +5,9 @@
 /// The EraVM version.
 pub const ZKEVM_VERSION: semver::Version = semver::Version::new(1, 3, 2);
 
+/// The deployed Yul object identifier suffix.
+pub static YUL_OBJECT_DEPLOYED_SUFFIX: &str = "_deployed";
+
 /// The heap memory pointer pointer global variable name.
 pub static GLOBAL_HEAP_MEMORY_POINTER: &str = "memory_pointer";
 

--- a/src/eravm/context/build.rs
+++ b/src/eravm/context/build.rs
@@ -2,8 +2,6 @@
 //! The LLVM module build.
 //!
 
-use std::collections::BTreeMap;
-
 ///
 /// The LLVM module build.
 ///
@@ -15,8 +13,6 @@ pub struct Build {
     pub bytecode_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
     /// The project metadata hash.
     pub metadata_hash: Option<Vec<u8>>,
-    /// The hash-to-full-path mapping of the contract factory dependencies.
-    pub factory_dependencies: BTreeMap<String, String>,
     /// The text assembly.
     pub assembly: Option<String>,
 }
@@ -35,7 +31,6 @@ impl Build {
             bytecode,
             bytecode_hash,
             metadata_hash,
-            factory_dependencies: BTreeMap::new(),
             assembly,
         }
     }

--- a/src/eravm/context/build.rs
+++ b/src/eravm/context/build.rs
@@ -2,6 +2,8 @@
 //! The LLVM module build.
 //!
 
+use std::collections::BTreeMap;
+
 ///
 /// The LLVM module build.
 ///
@@ -13,6 +15,8 @@ pub struct Build {
     pub bytecode_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
     /// The project metadata hash.
     pub metadata_hash: Option<Vec<u8>>,
+    /// The hash-to-full-path mapping of the contract factory dependencies.
+    pub factory_dependencies: BTreeMap<String, String>,
     /// The text assembly.
     pub assembly: Option<String>,
 }
@@ -23,14 +27,32 @@ impl Build {
     ///
     pub fn new(
         bytecode: Vec<u8>,
-        bytecode_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         metadata_hash: Option<Vec<u8>>,
         assembly: Option<String>,
     ) -> Self {
         Self {
             bytecode,
-            bytecode_hash,
+            bytecode_hash: None,
             metadata_hash,
+            factory_dependencies: BTreeMap::new(),
+            assembly,
+        }
+    }
+
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new_with_bytecode_hash(
+        bytecode: Vec<u8>,
+        bytecode_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD],
+        metadata_hash: Option<Vec<u8>>,
+        assembly: Option<String>,
+    ) -> Self {
+        Self {
+            bytecode,
+            bytecode_hash: Some(bytecode_hash),
+            metadata_hash,
+            factory_dependencies: BTreeMap::new(),
             assembly,
         }
     }

--- a/src/eravm/context/function/intrinsics.rs
+++ b/src/eravm/context/function/intrinsics.rs
@@ -21,8 +21,11 @@ pub struct Intrinsics<'ctx> {
     pub memory_move_heap: FunctionDeclaration<'ctx>,
     /// The memory copy from a generic page.
     pub memory_copy_from_generic: FunctionDeclaration<'ctx>,
+
     /// The linker symbol.
     pub linker_symbol: FunctionDeclaration<'ctx>,
+    /// The factory dependency.
+    pub factory_dependency: FunctionDeclaration<'ctx>,
 
     /// The event emitting.
     pub event: FunctionDeclaration<'ctx>,
@@ -70,6 +73,9 @@ impl<'ctx> Intrinsics<'ctx> {
 
     /// The corresponding intrinsic function name.
     pub const FUNCTION_LINKER_SYMBOL: &'static str = "llvm.eravm.linkersymbol";
+
+    /// The corresponding intrinsic function name.
+    pub const FUNCTION_FACTORY_DEPENDENCY: &'static str = "llvm.eravm.factorydependency";
 
     /// The corresponding intrinsic function name.
     pub const FUNCTION_EVENT: &'static str = "llvm.eravm.event";
@@ -167,10 +173,17 @@ impl<'ctx> Intrinsics<'ctx> {
                 false,
             ),
         );
+
         let linker_symbol = Self::declare(
             llvm,
             module,
             Self::FUNCTION_LINKER_SYMBOL,
+            field_type.fn_type(&[llvm.metadata_type().into()], false),
+        );
+        let factory_dependency = Self::declare(
+            llvm,
+            module,
+            Self::FUNCTION_FACTORY_DEPENDENCY,
             field_type.fn_type(&[llvm.metadata_type().into()], false),
         );
 
@@ -319,7 +332,9 @@ impl<'ctx> Intrinsics<'ctx> {
             trap,
             memory_move_heap,
             memory_copy_from_generic,
+
             linker_symbol,
+            factory_dependency,
 
             event,
             to_l1,

--- a/src/eravm/context/function/runtime/deployer_call.rs
+++ b/src/eravm/context/function/runtime/deployer_call.rs
@@ -316,6 +316,13 @@ where
             "deployer_call_address_or_status_code",
         )?;
         context.build_store(result_pointer, address_or_status_code)?;
+        context.reset_named_pointers(&[crate::eravm::GLOBAL_RETURN_DATA_POINTER])?;
+        context.set_global(
+            crate::eravm::GLOBAL_RETURN_DATA_SIZE,
+            context.field_type(),
+            AddressSpace::Stack,
+            context.field_const(0),
+        )?;
         context.build_unconditional_branch(context.current_function().borrow().return_block())?;
 
         context.set_basic_block(error_block);

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -15,7 +15,6 @@ pub mod yul_data;
 mod tests;
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -161,7 +160,6 @@ where
     pub fn build(
         mut self,
         contract_path: &str,
-        linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
         metadata_hash: Option<era_compiler_common::Hash>,
         output_assembly: bool,
         is_fallback_to_size: bool,
@@ -239,13 +237,7 @@ where
                     Function::set_size_attributes(self.llvm, function);
                 }
                 return self
-                    .build(
-                        contract_path,
-                        linker_symbols,
-                        metadata_hash,
-                        output_assembly,
-                        true,
-                    )
+                    .build(contract_path, metadata_hash, output_assembly, true)
                     .map_err(|error| {
                         anyhow::anyhow!("falling back to optimizing for size: {error}")
                     });
@@ -260,12 +252,7 @@ where
         let assembly_text = assembly_buffer
             .map(|assembly_buffer| String::from_utf8_lossy(assembly_buffer.as_slice()).to_string());
 
-        crate::eravm::build(
-            bytecode_buffer,
-            linker_symbols,
-            metadata_hash,
-            assembly_text,
-        )
+        crate::eravm::build(bytecode_buffer, metadata_hash, assembly_text)
     }
 
     ///

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -388,29 +388,13 @@ where
     }
 
     ///
-    /// Get the contract dependency data.
-    ///
-    pub fn get_dependency_data(&mut self, identifier: &str) -> anyhow::Result<Option<String>> {
-        if let Some(vyper_data) = self.vyper_data.as_mut() {
-            vyper_data.set_is_minimal_proxy_used();
-        }
-        self.dependency_manager
-            .as_ref()
-            .expect("Always exists")
-            .get_data(identifier)
-    }
-
-    ///
     /// Gets a full contract_path from the dependency manager.
     ///
     pub fn resolve_path(&self, identifier: &str) -> anyhow::Result<String> {
         self.dependency_manager
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("The dependency manager is unset"))
-            .and_then(|manager| {
-                let full_path = manager.resolve_path(identifier)?;
-                Ok(full_path)
-            })
+            .expect("Always exists")
+            .resolve_path(identifier)
     }
 
     ///
@@ -1163,57 +1147,47 @@ where
         self.solidity_data = Some(data);
     }
 
-    fn solidity(&self) -> &Self::SolidityData {
-        self.solidity_data
-            .as_ref()
-            .expect("The Solidity data must have been initialized")
+    fn solidity(&self) -> Option<&Self::SolidityData> {
+        self.solidity_data.as_ref()
     }
 
-    fn solidity_mut(&mut self) -> &mut Self::SolidityData {
-        self.solidity_data
-            .as_mut()
-            .expect("The Solidity data must have been initialized")
+    fn solidity_mut(&mut self) -> Option<&mut Self::SolidityData> {
+        self.solidity_data.as_mut()
     }
 
     fn set_yul_data(&mut self, data: Self::YulData) {
         self.yul_data = Some(data);
     }
 
-    fn yul(&self) -> &Self::YulData {
-        self.yul_data
-            .as_ref()
-            .expect("The Yul data must have been initialized")
+    fn yul(&self) -> Option<&Self::YulData> {
+        self.yul_data.as_ref()
     }
 
-    fn yul_mut(&mut self) -> &mut Self::YulData {
-        self.yul_data
-            .as_mut()
-            .expect("The Yul data must have been initialized")
+    fn yul_mut(&mut self) -> Option<&mut Self::YulData> {
+        self.yul_data.as_mut()
     }
 
     fn set_evmla_data(&mut self, data: Self::EVMLAData) {
         self.evmla_data = Some(data);
     }
 
-    fn evmla(&self) -> &Self::EVMLAData {
-        self.evmla_data
-            .as_ref()
-            .expect("The EVMLA data must have been initialized")
+    fn evmla(&self) -> Option<&Self::EVMLAData> {
+        self.evmla_data.as_ref()
     }
 
-    fn evmla_mut(&mut self) -> &mut Self::EVMLAData {
-        self.evmla_data
-            .as_mut()
-            .expect("The EVMLA data must have been initialized")
+    fn evmla_mut(&mut self) -> Option<&mut Self::EVMLAData> {
+        self.evmla_data.as_mut()
     }
 
     fn set_vyper_data(&mut self, data: Self::VyperData) {
         self.vyper_data = Some(data);
     }
 
-    fn vyper(&self) -> &Self::VyperData {
-        self.vyper_data
-            .as_ref()
-            .expect("The Vyper data must have been initialized")
+    fn vyper(&self) -> Option<&Self::VyperData> {
+        self.vyper_data.as_ref()
+    }
+
+    fn vyper_mut(&mut self) -> Option<&mut Self::VyperData> {
+        self.vyper_data.as_mut()
     }
 }

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -162,6 +162,7 @@ where
         mut self,
         contract_path: &str,
         linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
+        factory_dependencies: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         metadata_hash: Option<era_compiler_common::Hash>,
         output_assembly: bool,
         is_fallback_to_size: bool,
@@ -242,6 +243,7 @@ where
                     .build(
                         contract_path,
                         linker_symbols,
+                        factory_dependencies,
                         metadata_hash,
                         output_assembly,
                         true,
@@ -263,6 +265,7 @@ where
         crate::eravm::build(
             bytecode_buffer,
             linker_symbols,
+            factory_dependencies,
             metadata_hash,
             assembly_text,
         )
@@ -387,14 +390,14 @@ where
     ///
     /// Get the contract dependency data.
     ///
-    pub fn get_dependency_data(&mut self, identifier: &str) -> anyhow::Result<String> {
+    pub fn get_dependency_data(&mut self, identifier: &str) -> anyhow::Result<Option<String>> {
         if let Some(vyper_data) = self.vyper_data.as_mut() {
             vyper_data.set_is_minimal_proxy_used();
         }
         self.dependency_manager
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("The dependency manager is unset"))
-            .and_then(|manager| manager.get(identifier))
+            .expect("Always exists")
+            .get_data(identifier)
     }
 
     ///

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -162,7 +162,6 @@ where
         mut self,
         contract_path: &str,
         linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
-        factory_dependencies: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         metadata_hash: Option<era_compiler_common::Hash>,
         output_assembly: bool,
         is_fallback_to_size: bool,
@@ -243,7 +242,6 @@ where
                     .build(
                         contract_path,
                         linker_symbols,
-                        factory_dependencies,
                         metadata_hash,
                         output_assembly,
                         true,
@@ -265,7 +263,6 @@ where
         crate::eravm::build(
             bytecode_buffer,
             linker_symbols,
-            factory_dependencies,
             metadata_hash,
             assembly_text,
         )

--- a/src/eravm/context/tests.rs
+++ b/src/eravm/context/tests.rs
@@ -18,7 +18,7 @@ pub fn create_context(
     let module = llvm.create_module("test");
     let optimizer = Optimizer::new(optimizer_settings);
 
-    Context::<DummyDependency>::new(&llvm, module, vec![], optimizer, None, None)
+    Context::<DummyDependency>::new(&llvm, module, vec![], optimizer, None)
 }
 
 #[test]

--- a/src/eravm/context/tests.rs
+++ b/src/eravm/context/tests.rs
@@ -18,7 +18,7 @@ pub fn create_context(
     let module = llvm.create_module("test");
     let optimizer = Optimizer::new(optimizer_settings);
 
-    Context::<DummyDependency>::new(&llvm, module, vec![], optimizer, None)
+    Context::<_>::new(&llvm, module, vec![], optimizer, None)
 }
 
 #[test]

--- a/src/eravm/context/yul_data.rs
+++ b/src/eravm/context/yul_data.rs
@@ -16,6 +16,8 @@ pub struct YulData {
     /// The EraVM extensions flag.
     /// The call simulations only work if this mode is enabled.
     are_eravm_extensions_enabled: bool,
+    /// Mapping from Yul object identifiers to full contract paths.
+    identifier_paths: BTreeMap<String, String>,
     /// The list of constant arrays in the code section.
     /// It is a temporary storage used until the finalization method is called.
     const_arrays: BTreeMap<u8, Vec<num::BigUint>>,
@@ -25,9 +27,13 @@ impl YulData {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(are_eravm_extensions_enabled: bool) -> Self {
+    pub fn new(
+        are_eravm_extensions_enabled: bool,
+        identifier_paths: BTreeMap<String, String>,
+    ) -> Self {
         Self {
             are_eravm_extensions_enabled,
+            identifier_paths,
             const_arrays: BTreeMap::new(),
         }
     }
@@ -37,6 +43,15 @@ impl YulData {
     ///
     pub fn are_eravm_extensions_enabled(&self) -> bool {
         self.are_eravm_extensions_enabled
+    }
+
+    ///
+    /// Resolves the full contract path by the Yul object identifier.
+    ///
+    pub fn resolve_path(&self, identifier: &str) -> Option<&str> {
+        self.identifier_paths
+            .get(identifier)
+            .map(|path| path.as_str())
     }
 
     ///

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -48,14 +48,6 @@ where
         )?
         .expect("Always exists");
 
-    context.reset_named_pointers(&[crate::eravm::GLOBAL_RETURN_DATA_POINTER])?;
-    context.set_global(
-        crate::eravm::GLOBAL_RETURN_DATA_SIZE,
-        context.field_type(),
-        AddressSpace::Stack,
-        context.field_const(0),
-    )?;
-
     Ok(result)
 }
 
@@ -95,14 +87,6 @@ where
             "create2_deployer_call",
         )?
         .expect("Always exists");
-
-    context.reset_named_pointers(&[crate::eravm::GLOBAL_RETURN_DATA_POINTER])?;
-    context.set_global(
-        crate::eravm::GLOBAL_RETURN_DATA_SIZE,
-        context.field_type(),
-        AddressSpace::Stack,
-        context.field_const(0),
-    )?;
 
     Ok(result)
 }

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -130,16 +130,13 @@ where
 
     let parent = context.module().get_name().to_str().expect("Always valid");
 
-    let contract_path =
-        context
+    let contract_path = match context.yul() {
+        Some(yul_data) => yul_data
             .resolve_path(identifier.as_str())
-            .map_err(|error| match code_segment {
-                era_compiler_common::CodeSegment::Runtime if identifier.ends_with("_deployed") => {
-                    anyhow::anyhow!("type({}).runtimeCode is not supported", identifier)
-                }
-                _ => error,
-            })?;
-    if contract_path.as_str() == parent {
+            .unwrap_or(identifier.as_str()),
+        None => identifier.as_str(),
+    };
+    if contract_path == parent {
         return Ok(Value::new_with_constant(
             context.field_const(0).as_basic_value_enum(),
             num::BigUint::zero(),
@@ -155,10 +152,7 @@ where
             context.intrinsics().factory_dependency,
             &[context
                 .llvm()
-                .metadata_node(&[context
-                    .llvm()
-                    .metadata_string(contract_path.as_str())
-                    .into()])
+                .metadata_node(&[context.llvm().metadata_string(contract_path).into()])
                 .into()],
             format!("linker_symbol_{contract_path}").as_str(),
         )?
@@ -193,16 +187,13 @@ where
 
     let parent = context.module().get_name().to_str().expect("Always valid");
 
-    let contract_path =
-        context
+    let contract_path = match context.yul() {
+        Some(yul_data) => yul_data
             .resolve_path(identifier.as_str())
-            .map_err(|error| match code_segment {
-                era_compiler_common::CodeSegment::Runtime if identifier.ends_with("_deployed") => {
-                    anyhow::anyhow!("type({}).runtimeCode is not supported", identifier)
-                }
-                _ => error,
-            })?;
-    if contract_path.as_str() == parent {
+            .unwrap_or(identifier.as_str()),
+        None => identifier.as_str(),
+    };
+    if contract_path == parent {
         return Ok(Value::new_with_constant(
             context.field_const(0).as_basic_value_enum(),
             num::BigUint::zero(),

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -124,6 +124,10 @@ where
         .code_segment()
         .expect("Contract code segment type is undefined");
 
+    if let Some(vyper_data) = context.vyper_mut() {
+        vyper_data.set_is_minimal_proxy_used();
+    }
+
     let parent = context.module().get_name().to_str().expect("Always valid");
 
     let contract_path =
@@ -146,31 +150,20 @@ where
         anyhow::bail!("type({identifier}).runtimeCode is not supported");
     }
 
-    let value = match context.get_dependency_data(identifier.as_str())? {
-        Some(hash_string) => {
-            let hash_value = context
-                .field_const_str_hex(hash_string.as_str())
-                .as_basic_value_enum();
-            Value::new_with_original(hash_value, hash_string)
-        }
-        None => {
-            let value = context
-                .build_call_metadata(
-                    context.intrinsics().factory_dependency,
-                    &[context
-                        .llvm()
-                        .metadata_node(&[context
-                            .llvm()
-                            .metadata_string(contract_path.as_str())
-                            .into()])
-                        .into()],
-                    format!("linker_symbol_{contract_path}").as_str(),
-                )?
-                .expect("Always exists");
-            Value::new(value)
-        }
-    };
-    Ok(value)
+    let value = context
+        .build_call_metadata(
+            context.intrinsics().factory_dependency,
+            &[context
+                .llvm()
+                .metadata_node(&[context
+                    .llvm()
+                    .metadata_string(contract_path.as_str())
+                    .into()])
+                .into()],
+            format!("linker_symbol_{contract_path}").as_str(),
+        )?
+        .expect("Always exists");
+    Ok(Value::new(value))
 }
 
 ///

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -128,23 +128,31 @@ where
         vyper_data.set_is_minimal_proxy_used();
     }
 
-    let parent = context.module().get_name().to_str().expect("Always valid");
-
-    let contract_path = match context.yul() {
+    let current_module_name = context.module().get_name().to_str().expect("Always valid");
+    let full_path = match context.yul() {
         Some(yul_data) => yul_data
-            .resolve_path(identifier.as_str())
-            .unwrap_or(identifier.as_str()),
+            .resolve_path(
+                identifier
+                    .strip_suffix(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX)
+                    .unwrap_or(identifier.as_str()),
+            )
+            .expect("Always exists"),
         None => identifier.as_str(),
     };
-    if contract_path == parent {
-        return Ok(Value::new_with_constant(
-            context.field_const(0).as_basic_value_enum(),
-            num::BigUint::zero(),
-        ));
-    } else if identifier.ends_with("_deployed")
-        && code_segment == era_compiler_common::CodeSegment::Runtime
-    {
-        anyhow::bail!("type({identifier}).runtimeCode is not supported");
+
+    match code_segment {
+        era_compiler_common::CodeSegment::Deploy if full_path == current_module_name => {
+            return Ok(Value::new_with_constant(
+                context.field_const(0).as_basic_value_enum(),
+                num::BigUint::zero(),
+            ));
+        }
+        era_compiler_common::CodeSegment::Runtime
+            if identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+        {
+            anyhow::bail!("type({identifier}).runtimeCode is not supported");
+        }
+        _ => {}
     }
 
     let value = context
@@ -152,9 +160,9 @@ where
             context.intrinsics().factory_dependency,
             &[context
                 .llvm()
-                .metadata_node(&[context.llvm().metadata_string(contract_path).into()])
+                .metadata_node(&[context.llvm().metadata_string(full_path).into()])
                 .into()],
-            format!("linker_symbol_{contract_path}").as_str(),
+            format!("factory_dependency_{full_path}").as_str(),
         )?
         .expect("Always exists");
     Ok(Value::new(value))
@@ -185,23 +193,31 @@ where
         .code_segment()
         .expect("Contract code segment type is undefined");
 
-    let parent = context.module().get_name().to_str().expect("Always valid");
-
-    let contract_path = match context.yul() {
+    let current_module_name = context.module().get_name().to_str().expect("Always valid");
+    let full_path = match context.yul() {
         Some(yul_data) => yul_data
-            .resolve_path(identifier.as_str())
-            .unwrap_or(identifier.as_str()),
+            .resolve_path(
+                identifier
+                    .strip_suffix(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX)
+                    .unwrap_or(identifier.as_str()),
+            )
+            .expect("Always exists"),
         None => identifier.as_str(),
     };
-    if contract_path == parent {
-        return Ok(Value::new_with_constant(
-            context.field_const(0).as_basic_value_enum(),
-            num::BigUint::zero(),
-        ));
-    } else if identifier.ends_with("_deployed")
-        && code_segment == era_compiler_common::CodeSegment::Runtime
-    {
-        anyhow::bail!("type({identifier}).runtimeCode is not supported");
+
+    match code_segment {
+        era_compiler_common::CodeSegment::Deploy if full_path == current_module_name => {
+            return Ok(Value::new_with_constant(
+                context.field_const(0).as_basic_value_enum(),
+                num::BigUint::zero(),
+            ));
+        }
+        era_compiler_common::CodeSegment::Runtime
+            if identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+        {
+            anyhow::bail!("type({identifier}).runtimeCode is not supported");
+        }
+        _ => {}
     }
 
     let size_bigint = num::BigUint::from(crate::eravm::DEPLOYER_CALL_HEADER_SIZE);

--- a/src/eravm/extensions/const_array.rs
+++ b/src/eravm/extensions/const_array.rs
@@ -21,7 +21,10 @@ pub fn declare<'ctx, D>(
 where
     D: Dependency,
 {
-    context.yul_mut().const_array_declare(index, size)?;
+    context
+        .yul_mut()
+        .expect("Always exists")
+        .const_array_declare(index, size)?;
 
     Ok(context.field_const(1).as_basic_value_enum())
 }
@@ -38,7 +41,10 @@ pub fn set<'ctx, D>(
 where
     D: Dependency,
 {
-    context.yul_mut().const_array_set(index, offset, value)?;
+    context
+        .yul_mut()
+        .expect("Always exists")
+        .const_array_set(index, offset, value)?;
 
     Ok(context.field_const(1).as_basic_value_enum())
 }
@@ -54,7 +60,10 @@ pub fn finalize<'ctx, D>(
 where
     D: Dependency,
 {
-    let const_array = context.yul_mut().const_array_take(index)?;
+    let const_array = context
+        .yul_mut()
+        .expect("Always exists")
+        .const_array_take(index)?;
     let array_type = context.field_type().array_type(const_array.len() as u32);
     let array_value = context.field_type().const_array(
         const_array

--- a/src/eravm/mod.rs
+++ b/src/eravm/mod.rs
@@ -118,7 +118,6 @@ pub fn link(
 pub fn build(
     bytecode_buffer: inkwell::memory_buffer::MemoryBuffer,
     linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
-    factory_dependencies: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
     metadata_hash: Option<era_compiler_common::Hash>,
     assembly_text: Option<String>,
 ) -> anyhow::Result<Build> {
@@ -135,7 +134,7 @@ pub fn build(
     let (bytecode_buffer_linked, bytecode_hash) = self::link(
         bytecode_buffer_with_metadata,
         linker_symbols,
-        factory_dependencies,
+        &BTreeMap::new(),
     )?;
     let bytecode = bytecode_buffer_linked.as_slice().to_vec();
 

--- a/src/eravm/mod.rs
+++ b/src/eravm/mod.rs
@@ -117,7 +117,6 @@ pub fn link(
 ///
 pub fn build(
     bytecode_buffer: inkwell::memory_buffer::MemoryBuffer,
-    linker_symbols: &BTreeMap<String, [u8; era_compiler_common::BYTE_LENGTH_ETH_ADDRESS]>,
     metadata_hash: Option<era_compiler_common::Hash>,
     assembly_text: Option<String>,
 ) -> anyhow::Result<Build> {
@@ -131,14 +130,9 @@ pub fn build(
             .map_err(|error| anyhow::anyhow!("bytecode metadata appending error: {error}"))?,
         None => bytecode_buffer,
     };
-    let (bytecode_buffer_linked, bytecode_hash) = self::link(
-        bytecode_buffer_with_metadata,
-        linker_symbols,
-        &BTreeMap::new(),
-    )?;
-    let bytecode = bytecode_buffer_linked.as_slice().to_vec();
+    let bytecode = bytecode_buffer_with_metadata.as_slice().to_vec();
 
-    let build = Build::new(bytecode, bytecode_hash, metadata_hash, assembly_text);
+    let build = Build::new(bytecode, metadata_hash, assembly_text);
     Ok(build)
 }
 

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -193,11 +193,11 @@ where
     ///
     /// Get the contract dependency data.
     ///
-    pub fn get_dependency_data(&self, identifier: &str) -> anyhow::Result<String> {
-        self.dependency_manager
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("The dependency manager is unset"))
-            .and_then(|manager| Dependency::get(manager, identifier))
+    pub fn get_dependency_data(&self, identifier: &str) -> anyhow::Result<Option<String>> {
+        Dependency::get_data(
+            self.dependency_manager.as_ref().expect("Always exists"),
+            identifier,
+        )
     }
 
     ///

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -191,16 +191,6 @@ where
     }
 
     ///
-    /// Get the contract dependency data.
-    ///
-    pub fn get_dependency_data(&self, identifier: &str) -> anyhow::Result<Option<String>> {
-        Dependency::get_data(
-            self.dependency_manager.as_ref().expect("Always exists"),
-            identifier,
-        )
-    }
-
-    ///
     /// Gets a full contract_path from the dependency manager.
     ///
     pub fn resolve_path(&self, identifier: &str) -> anyhow::Result<String> {
@@ -535,11 +525,11 @@ where
         panic!("Unused with the EVM target");
     }
 
-    fn solidity(&self) -> &Self::SolidityData {
+    fn solidity(&self) -> Option<&Self::SolidityData> {
         panic!("Unused with the EVM target");
     }
 
-    fn solidity_mut(&mut self) -> &mut Self::SolidityData {
+    fn solidity_mut(&mut self) -> Option<&mut Self::SolidityData> {
         panic!("Unused with the EVM target");
     }
 
@@ -547,11 +537,11 @@ where
         panic!("Unused with the EVM target");
     }
 
-    fn yul(&self) -> &Self::YulData {
+    fn yul(&self) -> Option<&Self::YulData> {
         panic!("Unused with the EVM target");
     }
 
-    fn yul_mut(&mut self) -> &mut Self::YulData {
+    fn yul_mut(&mut self) -> Option<&mut Self::YulData> {
         panic!("Unused with the EVM target");
     }
 
@@ -559,23 +549,23 @@ where
         self.evmla_data = Some(data);
     }
 
-    fn evmla(&self) -> &Self::EVMLAData {
-        self.evmla_data
-            .as_ref()
-            .expect("The EVMLA data must have been initialized")
+    fn evmla(&self) -> Option<&Self::EVMLAData> {
+        self.evmla_data.as_ref()
     }
 
-    fn evmla_mut(&mut self) -> &mut Self::EVMLAData {
-        self.evmla_data
-            .as_mut()
-            .expect("The EVMLA data must have been initialized")
+    fn evmla_mut(&mut self) -> Option<&mut Self::EVMLAData> {
+        self.evmla_data.as_mut()
     }
 
     fn set_vyper_data(&mut self, _data: Self::VyperData) {
         panic!("Unused with the EVM target");
     }
 
-    fn vyper(&self) -> &Self::VyperData {
+    fn vyper(&self) -> Option<&Self::VyperData> {
+        panic!("Unused with the EVM target");
+    }
+
+    fn vyper_mut(&mut self) -> Option<&mut Self::VyperData> {
         panic!("Unused with the EVM target");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub use self::eravm::extensions::abi as eravm_abi;
 pub use self::eravm::extensions::call as eravm_call;
 pub use self::eravm::extensions::general as eravm_general;
 pub use self::eravm::extensions::math as eravm_math;
+pub use self::eravm::hash as eravm_hash;
 pub use self::eravm::link as eravm_link;
 pub use self::eravm::r#const as eravm_const;
 pub use self::eravm::utils as eravm_utils;


### PR DESCRIPTION
# What ❔

Adds the support for linking factory dependencies for EraVM.

## Why ❔

Contracts with unlinked libraries are not ready for deployment, and they cannot have the bytecode hash either.
It means that we need to link EraVM in two iterations: libraries first, factory dependencies later.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
