### PR TITLE
fix: remove the branch replacing call(0x04) with memcopy

### DIFF
--- a/src/eravm/evm/call.rs
+++ b/src/eravm/evm/call.rs
@@ -6,7 +6,6 @@ use inkwell::values::BasicValue;
 use num::ToPrimitive;
 
 use crate::context::function::declaration::Declaration as FunctionDeclaration;
-use crate::context::pointer::Pointer;
 use crate::context::IContext;
 use crate::eravm::context::address_space::AddressSpace;
 use crate::eravm::context::function::runtime::Runtime;
@@ -555,32 +554,7 @@ where
         }
     }
 
-    let identity_block = context.append_basic_block("contract_call_identity_block");
-    let ordinary_block = context.append_basic_block("contract_call_ordinary_block");
-    let join_block = context.append_basic_block("contract_call_join_block");
-
-    let result_pointer =
-        context.build_alloca(context.field_type(), "contract_call_result_pointer")?;
-    context.build_store(result_pointer, context.field_const(0))?;
-
-    context.builder().build_switch(
-        address,
-        ordinary_block,
-        &[(
-            context.field_const(zkevm_opcode_defs::ADDRESS_IDENTITY.into()),
-            identity_block,
-        )],
-    )?;
-
-    {
-        context.set_basic_block(identity_block);
-        let result = identity(context, output_offset, input_offset, output_length)?;
-        context.build_store(result_pointer, result)?;
-        context.build_unconditional_branch(join_block)?;
-    }
-
-    context.set_basic_block(ordinary_block);
-    let result = if let Some(value) = value {
+    if let Some(value) = value {
         default_wrapped(
             context,
             function,
@@ -591,7 +565,7 @@ where
             input_length,
             output_offset,
             output_length,
-        )?
+        )
     } else {
         let function = Runtime::default_call(context, function);
         context
@@ -606,15 +580,9 @@ where
                     output_length.as_basic_value_enum(),
                 ],
                 "default_call",
-            )?
-            .expect("Always exists")
-    };
-    context.build_store(result_pointer, result)?;
-    context.build_unconditional_branch(join_block)?;
-
-    context.set_basic_block(join_block);
-    let result = context.build_load(result_pointer, "contract_call_result")?;
-    Ok(result)
+            )
+            .map(|result| result.expect("Always exists"))
+    }
 }
 
 ///
@@ -767,41 +735,4 @@ where
     context.set_basic_block(value_join_block);
     let result = context.build_load(result_pointer, "contract_call_address_result")?;
     Ok(result)
-}
-
-///
-/// Generates a memory copy loop repeating the behavior of the EVM `Identity` precompile.
-///
-fn identity<'ctx, D>(
-    context: &mut Context<'ctx, D>,
-    destination: inkwell::values::IntValue<'ctx>,
-    source: inkwell::values::IntValue<'ctx>,
-    size: inkwell::values::IntValue<'ctx>,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: Dependency,
-{
-    let destination = Pointer::<AddressSpace>::new_with_offset(
-        context,
-        AddressSpace::Heap,
-        context.byte_type(),
-        destination,
-        "contract_call_identity_destination",
-    )?;
-    let source = Pointer::<AddressSpace>::new_with_offset(
-        context,
-        AddressSpace::Heap,
-        context.byte_type(),
-        source,
-        "contract_call_identity_source",
-    )?;
-
-    context.build_memcpy(
-        context.intrinsics().memory_move_heap,
-        destination,
-        source,
-        size,
-        "contract_call_memcpy_to_child",
-    )?;
-    Ok(context.field_const(1).as_basic_value_enum())
 }


### PR DESCRIPTION
Removes the branch replacing call(0x04) with memcopy.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
