### PR TITLE
fix: simplify EVMLA object naming

### DIFF
--- a/src/eravm/context/evmla_data.rs
+++ b/src/eravm/context/evmla_data.rs
@@ -19,7 +19,7 @@ pub struct EVMLAData<'ctx> {
     pub stack: Vec<Value<'ctx>>,
 }
 
-impl<'ctx> EVMLAData<'ctx> {
+impl EVMLAData<'_> {
     /// The default stack size.
     pub const DEFAULT_STACK_SIZE: usize = 64;
 

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -99,16 +99,7 @@ pub fn contract_hash<'ctx>(
         .code_segment()
         .expect("Contract code segment type is undefined");
 
-    let mut current_module_name = context
-        .module()
-        .get_name()
-        .to_str()
-        .expect("Always valid")
-        .to_owned();
-    if context.evmla().is_some() {
-        current_module_name
-            .push_str(format!(".{}", era_compiler_common::CodeSegment::Runtime).as_str());
-    }
+    let current_module_name = context.module().get_name().to_str().expect("Always valid");
 
     let full_path = match context.yul() {
         Some(yul_data) => yul_data
@@ -129,7 +120,16 @@ pub fn contract_hash<'ctx>(
             ));
         }
         era_compiler_common::CodeSegment::Runtime
-            if identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+            if context.yul().is_some()
+                && identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+        {
+            anyhow::bail!("type({identifier}).runtimeCode is not supported");
+        }
+        era_compiler_common::CodeSegment::Runtime
+            if context.evmla().is_some()
+                && identifier.ends_with(
+                    format!(".{}", era_compiler_common::CodeSegment::Runtime).as_str(),
+                ) =>
         {
             anyhow::bail!("type({identifier}).runtimeCode is not supported");
         }
@@ -171,16 +171,7 @@ pub fn header_size<'ctx>(
         .code_segment()
         .expect("Contract code segment type is undefined");
 
-    let mut current_module_name = context
-        .module()
-        .get_name()
-        .to_str()
-        .expect("Always valid")
-        .to_owned();
-    if context.evmla().is_some() {
-        current_module_name
-            .push_str(format!(".{}", era_compiler_common::CodeSegment::Runtime).as_str());
-    }
+    let current_module_name = context.module().get_name().to_str().expect("Always valid");
 
     let full_path = match context.yul() {
         Some(yul_data) => yul_data
@@ -201,7 +192,16 @@ pub fn header_size<'ctx>(
             ));
         }
         era_compiler_common::CodeSegment::Runtime
-            if identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+            if context.yul().is_some()
+                && identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+        {
+            anyhow::bail!("type({identifier}).runtimeCode is not supported");
+        }
+        era_compiler_common::CodeSegment::Runtime
+            if context.evmla().is_some()
+                && identifier.ends_with(
+                    format!(".{}", era_compiler_common::CodeSegment::Runtime).as_str(),
+                ) =>
         {
             anyhow::bail!("type({identifier}).runtimeCode is not supported");
         }

--- a/src/eravm/extensions/general.rs
+++ b/src/eravm/extensions/general.rs
@@ -212,5 +212,5 @@ pub fn event<'ctx>(
             "event_write"
         },
     )?;
-    return Ok(context.field_const(1).as_basic_value_enum());
+    Ok(context.field_const(1).as_basic_value_enum())
 }

--- a/src/evm/context/evmla_data.rs
+++ b/src/evm/context/evmla_data.rs
@@ -19,7 +19,7 @@ pub struct EVMLAData<'ctx> {
     pub stack: Vec<Value<'ctx>>,
 }
 
-impl<'ctx> EVMLAData<'ctx> {
+impl EVMLAData<'_> {
     /// The default stack size.
     pub const DEFAULT_STACK_SIZE: usize = 64;
 


### PR DESCRIPTION
# What ❔

Simplifies some EVMLA object namings.

## Why ❔

Needed to get rid of additional codegen checks in zksolc.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
