### PR TITLE
feat: enable fallback-Oz and check runtime code size

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.83.0"
+channel = "1.85.1"

--- a/src/evm/const.rs
+++ b/src/evm/const.rs
@@ -4,3 +4,6 @@
 
 /// The entry function name.
 pub const ENTRY_FUNCTION_NAME: &str = "__entry";
+
+/// The EVM bytecode size limit.
+pub const EVM_BYTECODE_SIZE_LIMIT: usize = 24576;

--- a/src/evm/context/function/mod.rs
+++ b/src/evm/context/function/mod.rs
@@ -178,6 +178,23 @@ impl<'ctx> Function<'ctx> {
     }
 
     ///
+    /// Sets the size optimization attributes.
+    ///
+    pub fn set_size_attributes(
+        llvm: &'ctx inkwell::context::Context,
+        function: inkwell::values::FunctionValue<'ctx>,
+    ) {
+        function.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::OptimizeForSize as u32, 0),
+        );
+        function.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            llvm.create_enum_attribute(Attribute::MinSize as u32, 0),
+        );
+    }
+
+    ///
     /// Saves the pointer to a stack variable, returning the pointer to the shadowed variable,
     /// if it exists.
     ///


### PR DESCRIPTION
1. Enables falling back to -Oz if the EVM runtime bytecode size is exceeded.
2. Enables the check for EVM runtime bytecode size of 24576 bytes.
3. Updates Rust to v1.85.1.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
