### PR TITLE
feat: mimic solc error codes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 
 [dependencies]
 anyhow = "=1.0.89"
+thiserror = "=1.0.64"
 semver = "=1.0.23"
 serde = { version = "=1.0.210", "features" = [ "derive" ] }
 num = "=0.4.3"

--- a/src/evm/const.rs
+++ b/src/evm/const.rs
@@ -5,5 +5,8 @@
 /// The entry function name.
 pub const ENTRY_FUNCTION_NAME: &str = "__entry";
 
-/// The EVM bytecode size limit.
-pub const EVM_BYTECODE_SIZE_LIMIT: usize = 24576;
+/// The EVM deploy bytecode size limit.
+pub const EVM_DEPLOY_CODE_SIZE_LIMIT: usize = 49152;
+
+/// The EVM runtime bytecode size limit.
+pub const EVM_RUNTIME_CODE_SIZE_LIMIT: usize = 24576;

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -5,6 +5,7 @@
 pub mod r#const;
 pub mod context;
 pub mod instructions;
+pub mod warning;
 
 use std::collections::BTreeMap;
 

--- a/src/evm/warning.rs
+++ b/src/evm/warning.rs
@@ -1,0 +1,45 @@
+//!
+//! EVM target warning.
+//!
+
+///
+/// EVM target warning.
+///
+#[derive(Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Warning {
+    /// Deploy code size warning.
+    #[error(
+        "{0} bytecode size is {found}B that exceeds the EVM limit of {1}B",
+        era_compiler_common::CodeSegment::Deploy,
+        crate::evm::r#const::EVM_DEPLOY_CODE_SIZE_LIMIT
+    )]
+    DeployCodeSize {
+        /// Bytecode size.
+        found: usize,
+    },
+
+    /// Runtime code size warning.
+    #[error(
+        "{0} bytecode size is {found}B that exceeds the EVM limit of {1}B",
+        era_compiler_common::CodeSegment::Runtime,
+        crate::evm::r#const::EVM_RUNTIME_CODE_SIZE_LIMIT
+    )]
+    RuntimeCodeSize {
+        /// Bytecode size.
+        found: usize,
+    },
+}
+
+impl Warning {
+    ///
+    /// Warning code.
+    ///
+    /// Mimic `solc` warning codes where possible for compatibility.
+    ///
+    pub fn code(&self) -> Option<isize> {
+        match self {
+            Self::DeployCodeSize { .. } => Some(3860),
+            Self::RuntimeCodeSize { .. } => Some(5574),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub use self::evm::instructions::return_data as evm_return_data;
 pub use self::evm::instructions::storage as evm_storage;
 pub use self::evm::link as evm_link;
 pub use self::evm::r#const as evm_const;
+pub use self::evm::warning::Warning as EVMWarning;
 pub use self::evm::DummyLLVMWritable as EVMDummyLLVMWritable;
 pub use self::evm::WriteLLVM as EVMWriteLLVM;
 pub use self::optimizer::settings::size_level::SizeLevel as OptimizerSettingsSizeLevel;


### PR DESCRIPTION
Adds an enum to mimic *solc* error codes.

For now, only for runtime code size.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
