### PR TITLE
chore: refactor outdated constants

### DIFF
--- a/src/const.rs
+++ b/src/const.rs
@@ -3,7 +3,13 @@
 //!
 
 /// The LLVM framework version.
-pub const LLVM_VERSION: semver::Version = semver::Version::new(15, 0, 4);
+pub const LLVM_VERSION: semver::Version = semver::Version::new(17, 0, 4);
+
+/// The entry function name.
+pub const ENTRY_FUNCTION_NAME: &str = "__entry";
+
+/// The deployed Yul object identifier suffix.
+pub static YUL_OBJECT_DEPLOYED_SUFFIX: &str = "_deployed";
 
 /// Library deploy address Yul identifier.
 pub static LIBRARY_DEPLOY_ADDRESS_TAG: &str = "library_deploy_address";

--- a/src/eravm/const.rs
+++ b/src/eravm/const.rs
@@ -3,10 +3,7 @@
 //!
 
 /// The EraVM version.
-pub const ZKEVM_VERSION: semver::Version = semver::Version::new(1, 3, 2);
-
-/// The deployed Yul object identifier suffix.
-pub static YUL_OBJECT_DEPLOYED_SUFFIX: &str = "_deployed";
+pub const ERAVM_VERSION: semver::Version = semver::Version::new(1, 5, 0);
 
 /// The heap memory pointer pointer global variable name.
 pub static GLOBAL_HEAP_MEMORY_POINTER: &str = "memory_pointer";

--- a/src/eravm/evm/create.rs
+++ b/src/eravm/evm/create.rs
@@ -105,7 +105,7 @@ pub fn contract_hash<'ctx>(
         Some(yul_data) => yul_data
             .resolve_path(
                 identifier
-                    .strip_suffix(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX)
+                    .strip_suffix(crate::r#const::YUL_OBJECT_DEPLOYED_SUFFIX)
                     .unwrap_or(identifier.as_str()),
             )
             .expect("Always exists"),
@@ -121,7 +121,7 @@ pub fn contract_hash<'ctx>(
         }
         era_compiler_common::CodeSegment::Runtime
             if context.yul().is_some()
-                && identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+                && identifier.ends_with(crate::r#const::YUL_OBJECT_DEPLOYED_SUFFIX) =>
         {
             anyhow::bail!("type({identifier}).runtimeCode is not supported");
         }
@@ -177,7 +177,7 @@ pub fn header_size<'ctx>(
         Some(yul_data) => yul_data
             .resolve_path(
                 identifier
-                    .strip_suffix(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX)
+                    .strip_suffix(crate::r#const::YUL_OBJECT_DEPLOYED_SUFFIX)
                     .unwrap_or(identifier.as_str()),
             )
             .expect("Always exists"),
@@ -193,7 +193,7 @@ pub fn header_size<'ctx>(
         }
         era_compiler_common::CodeSegment::Runtime
             if context.yul().is_some()
-                && identifier.ends_with(crate::eravm::YUL_OBJECT_DEPLOYED_SUFFIX) =>
+                && identifier.ends_with(crate::r#const::YUL_OBJECT_DEPLOYED_SUFFIX) =>
         {
             anyhow::bail!("type({identifier}).runtimeCode is not supported");
         }

--- a/src/evm/const.rs
+++ b/src/evm/const.rs
@@ -2,11 +2,8 @@
 //! The LLVM context constants.
 //!
 
-/// The entry function name.
-pub const ENTRY_FUNCTION_NAME: &str = "__entry";
+/// The deploy bytecode size limit.
+pub const DEPLOY_CODE_SIZE_LIMIT: usize = 49152;
 
-/// The EVM deploy bytecode size limit.
-pub const EVM_DEPLOY_CODE_SIZE_LIMIT: usize = 49152;
-
-/// The EVM runtime bytecode size limit.
-pub const EVM_RUNTIME_CODE_SIZE_LIMIT: usize = 24576;
+/// The runtime bytecode size limit.
+pub const RUNTIME_CODE_SIZE_LIMIT: usize = 24576;

--- a/src/evm/context/function/mod.rs
+++ b/src/evm/context/function/mod.rs
@@ -97,7 +97,7 @@ impl<'ctx> Function<'ctx> {
     ///
     pub fn is_name_external(name: &str) -> bool {
         name.starts_with("llvm.")
-            || (name.starts_with("__") && name != crate::evm_const::ENTRY_FUNCTION_NAME)
+            || (name.starts_with("__") && name != crate::r#const::ENTRY_FUNCTION_NAME)
     }
 
     ///

--- a/src/evm/context/function/runtime/entry.rs
+++ b/src/evm/context/function/runtime/entry.rs
@@ -39,7 +39,7 @@ where
     fn declare(&mut self, context: &mut Context) -> anyhow::Result<()> {
         let function_type = context.function_type::<inkwell::types::BasicTypeEnum>(vec![], 0);
         context.add_function(
-            crate::evm::r#const::ENTRY_FUNCTION_NAME,
+            crate::r#const::ENTRY_FUNCTION_NAME,
             function_type,
             0,
             Some(inkwell::module::Linkage::External),
@@ -49,7 +49,7 @@ where
     }
 
     fn into_llvm(self, context: &mut Context) -> anyhow::Result<()> {
-        context.set_current_function(crate::evm::r#const::ENTRY_FUNCTION_NAME)?;
+        context.set_current_function(crate::r#const::ENTRY_FUNCTION_NAME)?;
 
         context.set_basic_block(context.current_function().borrow().entry_block());
         self.inner.into_llvm(context)?;

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -167,7 +167,7 @@ impl<'ctx> Context<'ctx> {
 
         let mut warnings = Vec::with_capacity(1);
         let bytecode_size = buffer.as_slice().len();
-        if bytecode_size > crate::evm::r#const::EVM_DEPLOY_CODE_SIZE_LIMIT {
+        if bytecode_size > crate::evm::r#const::DEPLOY_CODE_SIZE_LIMIT {
             if self.optimizer.settings() != &OptimizerSettings::size()
                 && self.optimizer.settings().is_fallback_to_size_enabled()
             {

--- a/src/evm/warning.rs
+++ b/src/evm/warning.rs
@@ -11,7 +11,7 @@ pub enum Warning {
     #[error(
         "{0} bytecode size is {found}B that exceeds the EVM limit of {1}B",
         era_compiler_common::CodeSegment::Deploy,
-        crate::evm::r#const::EVM_DEPLOY_CODE_SIZE_LIMIT
+        crate::evm::r#const::DEPLOY_CODE_SIZE_LIMIT
     )]
     DeployCodeSize {
         /// Bytecode size.
@@ -22,7 +22,7 @@ pub enum Warning {
     #[error(
         "{0} bytecode size is {found}B that exceeds the EVM limit of {1}B",
         era_compiler_common::CodeSegment::Runtime,
-        crate::evm::r#const::EVM_RUNTIME_CODE_SIZE_LIMIT
+        crate::evm::r#const::RUNTIME_CODE_SIZE_LIMIT
     )]
     RuntimeCodeSize {
         /// Bytecode size.


### PR DESCRIPTION
Refactors a couple of outdated constants.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
