### PR TITLE
fix: EVM minimal deploy code used for LLVM IR

### DIFF
--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -75,14 +75,13 @@ pub fn minimal_deploy_code(runtime_code_length: usize) -> Vec<u8> {
     );
 
     static MINIMAL_DEPLOY_CODE: &[u8] = &[
-        0x61, 0x00, 0x00, // PUSH2 <runtime_length> (placeholder, big-endian)
-        0x60, 0x00, // PUSH1 0x00             (dest in memory = 0)
-        0x60, 0x0d, // PUSH1 0x0d             (offset where runtime code begins)
-        0x82, // DUP3                   (duplicate <runtime_length>)
-        0x39, // CODECOPY               (codecopy(0, 0x0d, <runtime_length>))
-        0x60, 0x00, // PUSH1 0x00             (return from memory offset = 0)
-        0x90, // SWAP1                  (put <runtime_length> on top)
-        0xF3, // RETURN                 (return memory[0..length])
+        0x61, 0x00, 0x00, // PUSH2 <runtime_length>    (placeholder, big-endian)
+        0x80, // DUP1                                  (duplicate <runtime_length>)
+        0x60, 0x0a, // PUSH1 0x0a                      (offset where runtime code begins)
+        0x5F, // PUSH0                                 (dest in memory = 0)
+        0x39, // CODECOPY                              (codecopy(0, 0x0d, <runtime_length>))
+        0x5F, // PUSH0                                 (return from memory offset = 0)
+        0xF3, // RETURN                                (return memory[0..length])
     ];
 
     let mut minimal_deploy_code = MINIMAL_DEPLOY_CODE.to_vec();


### PR DESCRIPTION
Fixes the minimal EVM deploy code constants used for compiling LLVM IR.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
