### PR TITLE
fix(evm): do not emit unreachable in entry function

### DIFF
--- a/src/evm/context/function/runtime/entry.rs
+++ b/src/evm/context/function/runtime/entry.rs
@@ -60,11 +60,12 @@ where
         {
             Some(inkwell::values::InstructionOpcode::Br) => {}
             Some(inkwell::values::InstructionOpcode::Switch) => {}
-            _ => context.build_unreachable()?,
+            _ => context
+                .build_unconditional_branch(context.current_function().borrow().return_block())?,
         }
 
         context.set_basic_block(context.current_function().borrow().return_block());
-        context.build_return(None)?;
+        crate::evm::instructions::r#return::stop(context)?;
 
         Ok(())
     }


### PR DESCRIPTION
# What ❔

Emits `evm.stop` instead of `unreachable` in `entry` function.

## Why ❔

It will gracefully return from an EVM contract if there is no more caller to jump back to.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
