### PR TITLE
fix: change the musl linker to rust-lld

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,10 +4,25 @@ rustflags = [
 ]
 incremental = true
 
-[env]
-LLVM_SYS_191_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = false }
-
 [tools.clippy]
 warn = [
     "missing_docs_in_private_items",
 ]
+
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-W", "missing_docs",
+    "-C", "link-arg=-mmacosx-version-min=11.0",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-W", "missing_docs",
+    "-C", "link-arg=-mmacosx-version-min=11.0",
+]
+
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"
+
+[env]
+LLVM_SYS_191_PREFIX = { value = "./target-llvm/target-final/", relative = true, force = false }


### PR DESCRIPTION
## Why ❔

The default one doesn't work.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
