### PR TITLE
fix: clean up interface for deploy-time linking

### DIFF
--- a/src/evm/build.rs
+++ b/src/evm/build.rs
@@ -18,8 +18,6 @@ pub struct Build {
     pub assembly: Option<String>,
     /// Mapping with immutables.
     pub immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
-    /// Unlinked symbols.
-    pub unlinked_symbols: Option<BTreeMap<String, Vec<u64>>>,
     /// Warnings produced during compilation.
     pub warnings: Vec<Warning>,
 }
@@ -32,14 +30,12 @@ impl Build {
         bytecode: Option<Vec<u8>>,
         assembly: Option<String>,
         immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
-        unlinked_symbols: Option<BTreeMap<String, Vec<u64>>>,
         warnings: Vec<Warning>,
     ) -> Self {
         Self {
             bytecode,
             assembly,
             immutables,
-            unlinked_symbols,
             warnings,
         }
     }

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -9,8 +9,6 @@ pub mod solidity_data;
 pub mod yul_data;
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -127,7 +125,6 @@ impl<'ctx> Context<'ctx> {
         mut self,
         output_assembly: bool,
         output_bytecode: bool,
-        unlinked_libraries: BTreeSet<String>,
     ) -> anyhow::Result<EVMBuild> {
         let module_clone = self.module.clone();
         let contract_path = self.module.get_name().to_str().expect("Always valid");
@@ -194,16 +191,6 @@ impl<'ctx> Context<'ctx> {
                 }
             };
 
-            let unlinked_symbols = unlinked_libraries
-                .iter()
-                .map(|library| {
-                    (
-                        library.to_owned(),
-                        bytecode_buffer.get_symbol_offsets_evm(library.as_str()),
-                    )
-                })
-                .collect::<BTreeMap<String, Vec<u64>>>();
-
             let mut warnings = Vec::with_capacity(1);
             let bytecode_size = bytecode_buffer.as_slice().len();
             if bytecode_size > crate::evm::r#const::DEPLOY_CODE_SIZE_LIMIT {
@@ -215,7 +202,7 @@ impl<'ctx> Context<'ctx> {
                     for function in self.module.get_functions() {
                         Function::set_size_attributes(self.llvm, function);
                     }
-                    return self.build(output_assembly, output_bytecode, unlinked_libraries);
+                    return self.build(output_assembly, output_bytecode);
                 } else {
                     warnings.push(match self.code_segment {
                         era_compiler_common::CodeSegment::Deploy => Warning::DeployCodeSize {
@@ -231,11 +218,10 @@ impl<'ctx> Context<'ctx> {
                 Some(bytecode_buffer.as_slice().to_vec()),
                 assembly,
                 immutables,
-                Some(unlinked_symbols),
                 warnings,
             ))
         } else {
-            Ok(EVMBuild::new(None, assembly, None, None, vec![]))
+            Ok(EVMBuild::new(None, assembly, None, vec![]))
         }
     }
 


### PR DESCRIPTION
Removes some redundant unused fields.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
