### PR TITLE
feat: add API for getting the spill area size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-commo
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "az-stack-never-too-deep"
+branch = "llvm-19"
 default-features = false
 features = ["llvm19-1", "serde", "no-libffi-linking", "target-eravm", "target-evm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-commo
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "llvm-19"
+branch = "az-stack-never-too-deep"
 default-features = false
 features = ["llvm19-1", "serde", "no-libffi-linking", "target-eravm", "target-evm"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.86.0"
+channel = "1.88.0"

--- a/src/context/traits/solidity_data.rs
+++ b/src/context/traits/solidity_data.rs
@@ -11,5 +11,5 @@ pub trait ISolidityData {
     ///
     /// Returns all runtime code offsets for the specified `id`.
     ///
-    fn offsets(&self, id: &str) -> Option<&BTreeSet<u64>>;
+    fn offsets(&mut self, id: &str) -> Option<BTreeSet<u64>>;
 }

--- a/src/debug_config/mod.rs
+++ b/src/debug_config/mod.rs
@@ -93,12 +93,16 @@ impl DebugConfig {
         contract_path: &str,
         module: &inkwell::module::Module,
         is_size_fallback: bool,
+        spill_area: Option<(u64, u64)>,
     ) -> anyhow::Result<()> {
         let llvm_code = module.print_to_string().to_string();
 
         let mut suffix = "unoptimized".to_owned();
         if is_size_fallback {
             suffix.push_str(".size_fallback");
+        }
+        if let Some((offset, size)) = spill_area {
+            suffix.push_str(format!(".o{offset}s{size}").as_str());
         }
 
         let mut file_path = self.output_directory.to_owned();
@@ -118,12 +122,16 @@ impl DebugConfig {
         contract_path: &str,
         module: &inkwell::module::Module,
         is_size_fallback: bool,
+        spill_area: Option<(u64, u64)>,
     ) -> anyhow::Result<()> {
         let llvm_code = module.print_to_string().to_string();
 
         let mut suffix = "optimized".to_owned();
         if is_size_fallback {
             suffix.push_str(".size_fallback");
+        }
+        if let Some((offset, size)) = spill_area {
+            suffix.push_str(format!(".o{offset}s{size}").as_str());
         }
 
         let mut file_path = self.output_directory.to_owned();

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -155,7 +155,6 @@ impl<'ctx> Context<'ctx> {
 
         let target_machine = TargetMachine::new(
             era_compiler_common::Target::EraVM,
-            self.code_segment,
             self.optimizer.settings(),
             self.llvm_options.as_slice(),
         )?;

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -155,6 +155,7 @@ impl<'ctx> Context<'ctx> {
 
         let target_machine = TargetMachine::new(
             era_compiler_common::Target::EraVM,
+            self.code_segment,
             self.optimizer.settings(),
             self.llvm_options.as_slice(),
         )?;
@@ -165,6 +166,7 @@ impl<'ctx> Context<'ctx> {
                 contract_path,
                 self.module(),
                 is_size_fallback,
+                None,
             )?;
         }
         self.verify()
@@ -174,7 +176,12 @@ impl<'ctx> Context<'ctx> {
             .run(&target_machine, self.module())
             .map_err(|error| anyhow::anyhow!("optimizing: {error}",))?;
         if let Some(ref debug_config) = self.debug_config {
-            debug_config.dump_llvm_ir_optimized(contract_path, self.module(), is_size_fallback)?;
+            debug_config.dump_llvm_ir_optimized(
+                contract_path,
+                self.module(),
+                is_size_fallback,
+                None,
+            )?;
         }
         self.verify()
             .map_err(|error| anyhow::anyhow!("optimized LLVM IR verification: {error}",))?;

--- a/src/eravm/context/mod.rs
+++ b/src/eravm/context/mod.rs
@@ -219,7 +219,7 @@ impl<'ctx> Context<'ctx> {
             .unwrap_or_default();
 
         if bytecode_buffer.exceeds_size_limit_eravm(metadata_size) {
-            if self.optimizer.settings() != &OptimizerSettings::size()
+            if self.optimizer.settings() == &OptimizerSettings::cycles()
                 && self.optimizer.settings().is_fallback_to_size_enabled()
             {
                 self.optimizer = Optimizer::new(OptimizerSettings::size());

--- a/src/eravm/context/solidity_data.rs
+++ b/src/eravm/context/solidity_data.rs
@@ -20,7 +20,7 @@ pub struct SolidityData {
 }
 
 impl ISolidityData for SolidityData {
-    fn offsets(&self, _id: &str) -> Option<&BTreeSet<u64>> {
+    fn offsets(&mut self, _id: &str) -> Option<BTreeSet<u64>> {
         None
     }
 }

--- a/src/eravm/evm/immutable.rs
+++ b/src/eravm/evm/immutable.rs
@@ -78,50 +78,50 @@ pub fn store<'ctx>(
     value: inkwell::values::IntValue<'ctx>,
 ) -> anyhow::Result<()> {
     match context.code_segment() {
-        None => {
-            anyhow::bail!("code segment is undefined");
-        }
-        Some(era_compiler_common::CodeSegment::Deploy) => {
-            let index_double = context.builder().build_int_mul(
-                index,
-                context.field_const(2),
-                "immutable_load_index_double",
-            )?;
-            let index_offset_absolute = context.builder().build_int_add(
-                index_double,
-                context.field_const(
-                    crate::eravm::HEAP_AUX_OFFSET_CONSTRUCTOR_RETURN_DATA
-                        + (2 * era_compiler_common::BYTE_LENGTH_FIELD) as u64,
-                ),
-                "index_offset_absolute",
-            )?;
-            let index_offset_pointer = Pointer::new_with_offset(
-                context,
-                AddressSpace::HeapAuxiliary,
-                context.field_type(),
-                index_offset_absolute,
-                "immutable_index_pointer",
-            )?;
-            context.build_store(index_offset_pointer, index)?;
-
-            let value_offset_absolute = context.builder().build_int_add(
-                index_offset_absolute,
-                context.field_const(era_compiler_common::BYTE_LENGTH_FIELD as u64),
-                "value_offset_absolute",
-            )?;
-            let value_offset_pointer = Pointer::new_with_offset(
-                context,
-                AddressSpace::HeapAuxiliary,
-                context.field_type(),
-                value_offset_absolute,
-                "immutable_value_pointer",
-            )?;
-            context.build_store(value_offset_pointer, value)?;
-
-            Ok(())
-        }
+        Some(era_compiler_common::CodeSegment::Deploy) => {}
         Some(era_compiler_common::CodeSegment::Runtime) => {
-            anyhow::bail!("immutable writes are not available in runtime code");
+            anyhow::bail!("Setting immutables is only allowed in deploy code");
+        }
+        None => {
+            anyhow::bail!("Code segment is undefined");
         }
     }
+
+    let index_double = context.builder().build_int_mul(
+        index,
+        context.field_const(2),
+        "immutable_load_index_double",
+    )?;
+    let index_offset_absolute = context.builder().build_int_add(
+        index_double,
+        context.field_const(
+            crate::eravm::HEAP_AUX_OFFSET_CONSTRUCTOR_RETURN_DATA
+                + (2 * era_compiler_common::BYTE_LENGTH_FIELD) as u64,
+        ),
+        "index_offset_absolute",
+    )?;
+    let index_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::HeapAuxiliary,
+        context.field_type(),
+        index_offset_absolute,
+        "immutable_index_pointer",
+    )?;
+    context.build_store(index_offset_pointer, index)?;
+
+    let value_offset_absolute = context.builder().build_int_add(
+        index_offset_absolute,
+        context.field_const(era_compiler_common::BYTE_LENGTH_FIELD as u64),
+        "value_offset_absolute",
+    )?;
+    let value_offset_pointer = Pointer::new_with_offset(
+        context,
+        AddressSpace::HeapAuxiliary,
+        context.field_type(),
+        value_offset_absolute,
+        "immutable_value_pointer",
+    )?;
+    context.build_store(value_offset_pointer, value)?;
+
+    Ok(())
 }

--- a/src/eravm/extensions/const_array.rs
+++ b/src/eravm/extensions/const_array.rs
@@ -98,9 +98,9 @@ pub fn get<'ctx>(
         pointer,
         &[context.field_const(0), offset],
         context.field_type().as_basic_type_enum(),
-        format!("{}_pointer", identifier).as_str(),
+        format!("{identifier}_pointer").as_str(),
     )?;
-    let value = context.build_load(pointer, format!("{}_value", identifier).as_str())?;
+    let value = context.build_load(pointer, format!("{identifier}_value").as_str())?;
 
     Ok(value)
 }

--- a/src/evm/const.rs
+++ b/src/evm/const.rs
@@ -7,3 +7,6 @@ pub const DEPLOY_CODE_SIZE_LIMIT: usize = 49152;
 
 /// The runtime bytecode size limit.
 pub const RUNTIME_CODE_SIZE_LIMIT: usize = 24576;
+
+/// The `solc` general memory offset.
+pub const SOLC_GENERAL_MEMORY_OFFSET: u64 = 128;

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -220,7 +220,7 @@ impl<'ctx> Context<'ctx> {
             let mut warnings = Vec::with_capacity(1);
             let bytecode_size = bytecode_buffer.as_slice().len();
             if bytecode_size > crate::evm::r#const::DEPLOY_CODE_SIZE_LIMIT {
-                if self.optimizer.settings() != &OptimizerSettings::size()
+                if self.optimizer.settings() == &OptimizerSettings::cycles()
                     && self.optimizer.settings().is_fallback_to_size_enabled()
                 {
                     self.optimizer = Optimizer::new(OptimizerSettings::size());

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -253,15 +253,6 @@ impl<'ctx> Context<'ctx> {
     }
 
     ///
-    /// Returns the spill area size.
-    ///
-    /// The size must be non-zero after the build has failed with a stack-too-deep error.
-    ///
-    pub fn spill_area_size(&self) -> u64 {
-        self.llvm.get_spill_area_size()
-    }
-
-    ///
     /// Verifies the current LLVM IR module.
     ///
     pub fn verify(&self) -> anyhow::Result<()> {

--- a/src/evm/context/mod.rs
+++ b/src/evm/context/mod.rs
@@ -132,7 +132,6 @@ impl<'ctx> Context<'ctx> {
 
         let target_machine = TargetMachine::new(
             era_compiler_common::Target::EVM,
-            Some(self.code_segment),
             self.optimizer.settings(),
             self.llvm_options.as_slice(),
         )?;
@@ -142,7 +141,7 @@ impl<'ctx> Context<'ctx> {
         let spill_area = self
             .optimizer
             .settings()
-            .spill_area_size(self.code_segment)
+            .spill_area_size()
             .map(|spill_area_size| {
                 (
                     crate::evm::r#const::SOLC_GENERAL_MEMORY_OFFSET,

--- a/src/evm/context/solidity_data.rs
+++ b/src/evm/context/solidity_data.rs
@@ -15,12 +15,28 @@ use crate::context::traits::solidity_data::ISolidityData;
 #[derive(Debug, Default)]
 pub struct SolidityData {
     /// The immutables identifier-to-offset mapping.
-    immutables: BTreeMap<String, BTreeSet<u64>>,
+    /// If the runtime code is available and this field is set, `offsets` method below can return `None`
+    /// for immutables that are never referenced in the runtime code,
+    /// However, if it is unset and `immutables_dummy` is used, then `offsets` method will always return
+    /// a set with a single offset to avoid stack-too-deep false negatives caused by missing immutable writing operations.
+    immutables: Option<BTreeMap<String, BTreeSet<u64>>>,
+    /// The dummy mapping that is used in dummy compiler runs.
+    /// For instance, when the runtime code with actual immutables is not available due to errors such as stack-too-deep,
+    /// but we still want to try compiling the deploy code to check for other errors including stack-too-deep.
+    /// In this case, `immutables` is `None`, and `immutables_dummy` is used to allocated the offsets of the immutables.
+    immutables_dummy: BTreeMap<String, u64>,
 }
 
 impl ISolidityData for SolidityData {
-    fn offsets(&self, id: &str) -> Option<&BTreeSet<u64>> {
-        self.immutables.get(id)
+    fn offsets(&mut self, id: &str) -> Option<BTreeSet<u64>> {
+        match self.immutables.as_ref() {
+            Some(immutables) => immutables.get(id).cloned(),
+            None => {
+                let mut offsets = BTreeSet::new();
+                offsets.insert(self.get_or_allocate_dummy_immutable(id));
+                Some(offsets)
+            }
+        }
     }
 }
 
@@ -28,7 +44,43 @@ impl SolidityData {
     ///
     /// A shortcut constructor.
     ///
-    pub fn new(immutables: BTreeMap<String, BTreeSet<u64>>) -> Self {
-        Self { immutables }
+    pub fn new(immutables: Option<BTreeMap<String, BTreeSet<u64>>>) -> Self {
+        Self {
+            immutables,
+            immutables_dummy: BTreeMap::new(),
+        }
+    }
+
+    ///
+    /// Returns the current number of immutables values in the contract.
+    ///
+    pub fn immutables_dummy_size(&self) -> usize {
+        self.immutables_dummy.len() * era_compiler_common::BYTE_LENGTH_FIELD
+    }
+
+    ///
+    /// Allocates memory for an immutable value in the auxiliary heap.
+    ///
+    /// If the identifier is already known, just returns its offset.
+    ///
+    pub fn allocate_dummy_immutable(&mut self, identifier: &str) -> u64 {
+        let number_of_elements = self.immutables_dummy.len();
+        let new_offset = number_of_elements * era_compiler_common::BYTE_LENGTH_FIELD;
+        *self
+            .immutables_dummy
+            .entry(identifier.to_owned())
+            .or_insert(new_offset as u64)
+    }
+
+    ///
+    /// Gets the offset of the immutable value.
+    ///
+    /// If the value is not yet allocated, then it is done forcibly.
+    ///
+    pub fn get_or_allocate_dummy_immutable(&mut self, identifier: &str) -> u64 {
+        match self.immutables_dummy.get(identifier).copied() {
+            Some(offset) => offset,
+            None => self.allocate_dummy_immutable(identifier),
+        }
     }
 }

--- a/src/evm/instructions/event.rs
+++ b/src/evm/instructions/event.rs
@@ -77,7 +77,7 @@ pub fn log<'ctx>(
             ],
             "log4",
         ),
-        length => panic!("The number of topics must be from 0 to 4, found {}", length),
+        length => panic!("The number of topics must be from 0 to 4, found {length}"),
     }?;
     Ok(())
 }

--- a/src/optimizer/settings/mod.rs
+++ b/src/optimizer/settings/mod.rs
@@ -22,6 +22,11 @@ pub struct Settings {
     /// Fallback to optimizing for size if the bytecode is too large.
     pub is_fallback_to_size_enabled: bool,
 
+    /// Deploy code spill area size.
+    pub deploy_code_spill_area_size: Option<u64>,
+    /// Runtime code spill area size.
+    pub runtime_code_spill_area_size: Option<u64>,
+
     /// Whether the LLVM `verify each` option is enabled.
     pub is_verify_each_enabled: bool,
     /// Whether the LLVM `debug logging` option is enabled.
@@ -46,6 +51,9 @@ impl Settings {
             level_back_end,
             is_fallback_to_size_enabled: false,
 
+            deploy_code_spill_area_size: None,
+            runtime_code_spill_area_size: None,
+
             is_verify_each_enabled: false,
             is_debug_logging_enabled: false,
         }
@@ -67,6 +75,9 @@ impl Settings {
             level_middle_end_size,
             level_back_end,
             is_fallback_to_size_enabled: false,
+
+            deploy_code_spill_area_size: None,
+            runtime_code_spill_area_size: None,
 
             is_verify_each_enabled,
             is_debug_logging_enabled,
@@ -245,6 +256,30 @@ impl Settings {
     ///
     pub fn is_fallback_to_size_enabled(&self) -> bool {
         self.is_fallback_to_size_enabled
+    }
+
+    ///
+    /// Sets the deploy code spill area size.
+    ///
+    pub fn set_deploy_code_spill_area_size(&mut self, size: u64) {
+        self.deploy_code_spill_area_size = Some(size);
+    }
+
+    ///
+    /// Returns the spill area size depending on the code segment.
+    ///
+    pub fn spill_area_size(&self, code_segment: era_compiler_common::CodeSegment) -> Option<u64> {
+        match code_segment {
+            era_compiler_common::CodeSegment::Deploy => self.deploy_code_spill_area_size,
+            era_compiler_common::CodeSegment::Runtime => self.runtime_code_spill_area_size,
+        }
+    }
+
+    ///
+    /// Sets the runtime code spill area size.
+    ///
+    pub fn set_runtime_code_spill_area_size(&mut self, size: u64) {
+        self.runtime_code_spill_area_size = Some(size);
     }
 }
 

--- a/src/optimizer/settings/mod.rs
+++ b/src/optimizer/settings/mod.rs
@@ -22,10 +22,8 @@ pub struct Settings {
     /// Fallback to optimizing for size if the bytecode is too large.
     pub is_fallback_to_size_enabled: bool,
 
-    /// Deploy code spill area size.
-    pub deploy_code_spill_area_size: Option<u64>,
-    /// Runtime code spill area size.
-    pub runtime_code_spill_area_size: Option<u64>,
+    /// Size of the spill area used for stack-too-deep mitigation.
+    pub spill_area_size: Option<u64>,
 
     /// Whether the LLVM `verify each` option is enabled.
     pub is_verify_each_enabled: bool,
@@ -51,8 +49,7 @@ impl Settings {
             level_back_end,
             is_fallback_to_size_enabled: false,
 
-            deploy_code_spill_area_size: None,
-            runtime_code_spill_area_size: None,
+            spill_area_size: None,
 
             is_verify_each_enabled: false,
             is_debug_logging_enabled: false,
@@ -76,8 +73,7 @@ impl Settings {
             level_back_end,
             is_fallback_to_size_enabled: false,
 
-            deploy_code_spill_area_size: None,
-            runtime_code_spill_area_size: None,
+            spill_area_size: None,
 
             is_verify_each_enabled,
             is_debug_logging_enabled,
@@ -261,25 +257,15 @@ impl Settings {
     ///
     /// Sets the deploy code spill area size.
     ///
-    pub fn set_deploy_code_spill_area_size(&mut self, size: u64) {
-        self.deploy_code_spill_area_size = Some(size);
+    pub fn set_spill_area_size(&mut self, size: u64) {
+        self.spill_area_size = Some(size);
     }
 
     ///
     /// Returns the spill area size depending on the code segment.
     ///
-    pub fn spill_area_size(&self, code_segment: era_compiler_common::CodeSegment) -> Option<u64> {
-        match code_segment {
-            era_compiler_common::CodeSegment::Deploy => self.deploy_code_spill_area_size,
-            era_compiler_common::CodeSegment::Runtime => self.runtime_code_spill_area_size,
-        }
-    }
-
-    ///
-    /// Sets the runtime code spill area size.
-    ///
-    pub fn set_runtime_code_spill_area_size(&mut self, size: u64) {
-        self.runtime_code_spill_area_size = Some(size);
+    pub fn spill_area_size(&self) -> Option<u64> {
+        self.spill_area_size
     }
 }
 

--- a/src/target_machine.rs
+++ b/src/target_machine.rs
@@ -32,7 +32,6 @@ impl TargetMachine {
     ///
     pub fn new(
         target: era_compiler_common::Target,
-        code_segment: Option<era_compiler_common::CodeSegment>,
         optimizer_settings: &OptimizerSettings,
         llvm_options: &[String],
     ) -> anyhow::Result<Self> {
@@ -40,16 +39,7 @@ impl TargetMachine {
         arguments.push(target.to_string());
         arguments.extend_from_slice(llvm_options);
         if let era_compiler_common::Target::EVM = target {
-            let spill_area_size = match code_segment {
-                Some(era_compiler_common::CodeSegment::Deploy) => {
-                    optimizer_settings.deploy_code_spill_area_size
-                }
-                Some(era_compiler_common::CodeSegment::Runtime) => {
-                    optimizer_settings.runtime_code_spill_area_size
-                }
-                None => None,
-            };
-            if let Some(size) = spill_area_size {
+            if let Some(size) = optimizer_settings.spill_area_size {
                 arguments.push(format!(
                     "-evm-stack-region-offset={}",
                     crate::evm::r#const::SOLC_GENERAL_MEMORY_OFFSET


### PR DESCRIPTION
Adds API for getting the spill area size.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
