### PR TITLE
feat(evm): add an LLVM attribute for EVM entry functions

### DIFF
--- a/src/evm/attribute.rs
+++ b/src/evm/attribute.rs
@@ -1,0 +1,33 @@
+//!
+//! The EVM string attribute.
+//!
+
+///
+/// The EVM string attribute.
+///
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum Attribute {
+    /// The corresponding value.
+    EVMEntryFunction,
+}
+
+impl std::str::FromStr for Attribute {
+    type Err = anyhow::Error;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        match string {
+            "evm-entry-function" => Ok(Attribute::EVMEntryFunction),
+            _ => anyhow::bail!("Unknown attribute: {string}"),
+        }
+    }
+}
+
+impl std::fmt::Display for Attribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Attribute::EVMEntryFunction => write!(f, "evm-entry-function"),
+        }
+    }
+}

--- a/src/evm/context/function/runtime/entry.rs
+++ b/src/evm/context/function/runtime/entry.rs
@@ -3,6 +3,7 @@
 //!
 
 use crate::context::IContext;
+use crate::evm::attribute::Attribute;
 use crate::evm::context::Context;
 use crate::evm::WriteLLVM;
 
@@ -38,12 +39,18 @@ where
 {
     fn declare(&mut self, context: &mut Context) -> anyhow::Result<()> {
         let function_type = context.function_type::<inkwell::types::BasicTypeEnum>(vec![], 0);
-        context.add_function(
+        let function = context.add_function(
             crate::r#const::ENTRY_FUNCTION_NAME,
             function_type,
             0,
             Some(inkwell::module::Linkage::External),
         )?;
+        function.borrow().declaration().value.add_attribute(
+            inkwell::attributes::AttributeLoc::Function,
+            context
+                .llvm()
+                .create_string_attribute(Attribute::EVMEntryFunction.to_string().as_str(), ""),
+        );
 
         self.inner.declare(context)
     }

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -2,6 +2,7 @@
 //! The LLVM EVM context library.
 //!
 
+pub mod attribute;
 pub mod build;
 pub mod r#const;
 pub mod context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub use self::eravm::DummyLLVMWritable as EraVMDummyLLVMWritable;
 pub use self::eravm::WriteLLVM as EraVMWriteLLVM;
 pub use self::evm::append_metadata as evm_append_metadata;
 pub use self::evm::assemble as evm_assemble;
+pub use self::evm::attribute::Attribute as EVMAttribute;
 pub use self::evm::build::Build as EVMBuild;
 pub use self::evm::context::address_space::AddressSpace as EVMAddressSpace;
 pub use self::evm::context::evmla_data::EVMLAData as EVMContextEVMLAData;


### PR DESCRIPTION
# What ❔

Adds an LLVM string attribute `evm-entry-function` for EVM entry functions.

## Why ❔

It is needed for LLVM to always put the entry function at the beginning of the bytecode without fragile explicit checks for function names.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
