### PR TITLE
chore: bump zkevm_opcode_defs and sha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,9 @@ semver = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 num = "0.4"
 itertools = "0.14"
-indexmap = { version = "2.10", features = ["serde"] }
+indexmap = { version = "2.11", features = ["serde"] }
 
-zkevm_opcode_defs = "=0.150.6"
-
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", branch = "main" }
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]


### PR DESCRIPTION
# What ❔

Bumps sha2 to v0.10.9.

## Why ❔

Can't update `revm` in compiler-tester otherwise.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
